### PR TITLE
Fix changelog reference for kubectl pronunciation

### DIFF
--- a/style-guide.md
+++ b/style-guide.md
@@ -38,7 +38,7 @@ middle of the word ("ubernete") with the number of letters it contains (8). K8s 
 *Additional notes:*
 
 1. Contrary to the pronunciation of Kubernetes, [KubeCon](http://kubecon.io) is pronounced KYOOB-kon.
-2. The correct pronunciation of kubectl was [established in v1.9](https://github.com/kubernetes/kubernetes/blame/master/CHANGELOG-1.9.md#L1125) as "cube-control".
+2. The correct pronunciation of kubectl was [established in v1.9](https://github.com/kubernetes/kubernetes/blame/master/CHANGELOG-1.9.md#L1285) as "cube-control".
 
 ## 3. Other CNCF Projects ##
 


### PR DESCRIPTION
Simple fix in the reference of line number to the changelog