### PR TITLE
Contact the K8s CoCC instead of Sarah going forward

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -42,7 +42,7 @@ Conduct may be permanently removed from the project team.
 This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a CNCF project maintainer, Sarah Novotny <sarahnovotny@google.com>, and/or Dan Kohn <dan@linuxfoundation.org>.
+Instances of abusive, harassing, or otherwise unacceptable behavior in Kubernetes may be reported by contacting the [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) via <conduct@kubernetes.io>, for other projects please contact a CNCF project maintainer or Dan Kohn <dan@linuxfoundation.org>.
 
 This Code of Conduct is adapted from the Contributor Covenant
 (http://contributor-covenant.org), version 1.2.0, available at

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -42,7 +42,7 @@ Conduct may be permanently removed from the project team.
 This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior in Kubernetes may be reported by contacting the [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) via <conduct@kubernetes.io>, for other projects please contact a CNCF project maintainer or Dan Kohn <dan@linuxfoundation.org>.
+Instances of abusive, harassing, or otherwise unacceptable behavior in Kubernetes may be reported by contacting the [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) via <conduct@kubernetes.io>. For other projects, please contact a CNCF project maintainer or Dan Kohn <dan@linuxfoundation.org>.
 
 This Code of Conduct is adapted from the Contributor Covenant
 (http://contributor-covenant.org), version 1.2.0, available at


### PR DESCRIPTION
The Kubernetes CoC docs all link back here, and I wanted to make sure that people know about the new k8s CoCC email address.

If this wording is okay, I'll try to replicate it on the translated pages as well.