### PR TITLE
Fix typo in the Spanish CNCF CoC

### DIFF
--- a/code-of-conduct-languages/es.md
+++ b/code-of-conduct-languages/es.md
@@ -20,7 +20,7 @@ Los mantenedores de proyectos tienen el derecho y la responsabilidad de eliminar
 
 Este Código de Conducta se aplica tanto dentro de los espacios relacionados con el proyecto como en espacios públicos y siempre que un individuo esté representando al proyecto o su comunidad.
 
-Los casos de comportamiento abusivo, acosador o de cualquier otro modo inaceptable podrán ser denunciados poniéndose en contacto con [Comité del Código de Conducta de Kubernetes](https://git.k8s.io/community/committee-code-of-conduct) al email <conduct@kubernetes.io>. Para otros proyectos, comuníquese con un mantenedor de proyectos de CNCF o con nuestra mediadora, Mishi Choudhary <mishi@linux.com>.
+Los casos de comportamiento abusivo, acosador o de cualquier otro modo inaceptable podrán ser denunciados poniéndose en contacto con el [Comité del Código de Conducta de Kubernetes](https://git.k8s.io/community/committee-code-of-conduct) en <conduct@kubernetes.io>. Para otros proyectos, comuníquese con un mantenedor de proyectos de CNCF o con nuestra mediadora, Mishi Choudhary <mishi@linux.com>.
 
 Este Código de Conducta está adaptado del Compromiso de Colaboradores (http://contributor-covenant.org), versión 1.2.0, disponible en http://contributor-covenant.org/version/1/2/0/
 


### PR DESCRIPTION
During the https://github.com/kubernetes/website/pull/13543, @alexbrand spot a typo in the CNCF CoC Spanish version.

As stated in the README, the CNCF CoC can only be copied from the original, so we would like to fix the typo in the source to be able to update the website copy.