### PR TITLE
Add Vietnamese language for Code of Conduct

### DIFF
--- a/code-of-conduct-languages/vi.md
+++ b/code-of-conduct-languages/vi.md
@@ -1,0 +1,28 @@
+## Quy tắc ứng xử cộng đồng CNCF v1.0
+
+### Quy tắc ứng xử của những người đóng góp
+
+Là những người đóng góp và duy trì dự án này, và vì việc thúc đẩy một cộng đồng mở và sẵn sàng chào đón, chúng tôi cam kết tôn trọng tất cả những người đóng góp thông qua việc báo cáo những vấn đề, yêu cầu tính năng, cập nhật tài liệu, tạo các Pull Requests hoặc bản vá và những hoạt động khác.
+
+Chúng tôi cam kết khi tham gia vào dự án này, mọi người sẽ không bị quấy rối, bất kể mức độ kinh nghiệm, giới tính, khuynh hướng tình dục, khuyết tật, ngoại hình, kích thước cơ thể, chủng tộc, tuổi tác, tôn giáo hoặc Quốc tịch.
+
+Các ví dụ về hành vi không được chấp nhận của người tham gia, gồm:
+
+* Sử dụng ngôn ngữ hoặc hình ảnh đồi trụy
+* Công kích cá nhân
+* Bình luận lăng mạ/xúc phạm
+* Quấy rối công khai hoặc riêng tư
+* Công bố thông tin cá nhân của người khác như địa chỉ chỗ ở hoặc địa chỉ điện tử khi không có sự cho phép rõ ràng
+* Hành vi phi đạo đức hoặc cư xử không chuyên nghiệp khác
+
+Người duy trì dự án có quyền và trách nhiệm xóa, chỉnh sửa hoặc từ chối các bình luận, commits, mã nguồn, chỉnh sửa wiki, các issues, và các đóng góp khác mà không phù hợp với quy tắc ứng xử này. Khi đưa vào bộ quy tắc ứng xử này, những người duy trì dự án cam kết áp dụng một cách công bằng và nhất quán các nguyên tắc này cho mọi khía cạnh của việc quản lý dự án. Những người duy trì dự án không tuân theo hoặc thực thi Quy tắc ứng xử có thể bị xóa tên vinh viễn khỏi nhóm dự án.
+
+Quy tắc ứng xử này áp dụng cả trong không gian dự án và không gian công cộng khi một cá nhân đại diện cho dự án hoặc cộng đồng của dự án.
+
+Các trường hợp lạm dụng, quấy rối hoặc những hành vi không thể chấp nhận được trong Kubernetes có thể báo cáo bằng cách liên hệ với [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) qua <conduct@kubernetes.io>. Đối với những dự án khác, vui lòng liên hệ với người duy trì dự án CNCF hoặc người hòa giải của chúng tôi, Mishi Choudhary <mishi@linux.com>.
+
+Quy tắc ứng xử này được điều chỉnh từ quy ước người đóng góp (http://contributor-covenant.org), phiên bản 1.2.0, tại http://contributor-covenant.org/version/1/2/0/
+
+### Quy tắc ứng xử của các sự kiện CNCF
+
+Các sự kiện CNCF được điều chỉnh bởi [Quy tắc ứng xử](https://events.linuxfoundation.org/code-of-conduct/) của Linux Foundation ở trên trang sự kiện. Nó được thiết kế để tương thích với chính sách trên và cũng bao gồm nhiều chi tiết hơn về việc ứng phó với các sự cố.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -11,6 +11,7 @@ Other languages available:
 - [Ukrainian/Українська](code-of-conduct-languages/uk.md)
 - [Russian/Русский](code-of-conduct-languages/ru.md)
 - [Portuguese/Português](code-of-conduct-languages/pt.md)
+- [Vietnamese/Tiếng Việt](code-of-conduct-languages/vi.md)
 
 ### Contributor Code of Conduct
 


### PR DESCRIPTION
Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>