### PR TITLE
Fixed apostrophe in others

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -30,7 +30,7 @@ Examples of unacceptable behavior by participants include:
 * Personal attacks
 * Trolling or insulting/derogatory comments
 * Public or private harassment
-* Publishing other's private information, such as physical or electronic addresses,
+* Publishing others' private information, such as physical or electronic addresses,
  without explicit permission
 * Other unethical or unprofessional conduct.
 


### PR DESCRIPTION
This PR fixes the apostrophe in the sentence "Publishing other's private information...": as it is plural, it should be "others'". 