### PR TITLE
Updated copyright hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repo contains several documents related to the operation of the [Cloud Nati
 
 ## Project Guidance
 
-* [Copyright](copyright.md) notice recommendations
+* [Copyright](copyright-notices.md) notice recommendations
 * [Website guidelines](website-guidelines.md) for mentioning companies while maintaining neutrality
 * [Whitelist policy](whitelist-policy.md) for which licenses are acceptable in upstream dependencies without requiring an explicit vote of the governing board
 


### PR DESCRIPTION
fixing 404 link to point to a working link

OLD https://github.com/cncf/foundation/blob/master/copyright.md
NEW https://github.com/cncf/foundation/blob/master/copyright-notices.md