### PR TITLE
Add Polish translation of Code of Conduct

### DIFF
--- a/code-of-conduct-languages/pl.md
+++ b/code-of-conduct-languages/pl.md
@@ -1,0 +1,43 @@
+## Kodeks Postępowania Społeczności CNCF v1.0
+
+### Kodeks postępowania współtwórców projektu
+
+My, współtwórcy i gospodarze tego projektu, dbając o to, aby nasza społeczność była otwarta i przyjazna,
+zobowiązujemy się szanować wszystkich, którzy uczestniczą w projekcie
+zgłaszając problemy, prośby o dodatkowe funkcjonalności, aktualizując dokumentację,
+rozbudowując lub poprawiając oprogramowanie, a także angażując się na inne sposoby.
+
+Staramy się, aby udział w tym projekcie był wolny od jakichkolwiek form nękania dla każdego,
+bez względu na doświadczenie, płeć, orientację i identyfikację seksualną,
+niepełnosprawność, wygląd zewnętrzny, budowę ciała, kolor skóry, pochodzenie etniczne, wiek,
+wyznawaną religię czy narodowość.
+
+Przykładowe zachowania, które są nieakceptowalne:
+
+* Używanie języka lub obrazów o podtekście seksualnym,
+* Ataki osobiste,
+* Trollowanie, obraźliwe bądź urągające komentarze,
+* Nękanie, zarówno na forum publicznym, jak i prywatnie,
+* Publikowanie danych osobistych innych osób — takich jak adres fizyczny, czy elektroniczny —
+bez ich wyraźnej zgody,
+* Inne zachowania nieetyczne lub nieprofesjonalne.
+
+Opiekunowie projektu mają prawo i są odpowiedzialni za usuwanie, edycję oraz odrzucanie komentarzy,
+zmian w kodzie (*commits*), edycji Wiki, oraz innych treści, które łamią niniejszy Kodeks Postępowania.
+Przyjmując ten Kodeks Postępowania, opiekunowie projektu
+zobowiązali sie do rzetelnego i konsekwentnego stosowania tych zasad w każdym aspekcie
+zarządzania tym projektem. Opiekunowie projektu, którzy nie respektują i nie egzekwują Kodeksu Postępowania,
+mogą zostać na stałe usunięci z zespołu projektowego.
+
+Ten Kodeks Postępowania ma zastosowanie w obrębie projektu, a także w sferze publicznej,
+jeśli indywidualna osoba reprezentuje projekt lub jego społeczność.
+
+Przypadki nękania, gróźb oraz innych form nieakceptowalnego zachowania w projekcie Kubernetes mogą być zgłaszane poprzez kontakt z [Komitetem Kodeksu Postępowania](https://git.k8s.io/community/committee-code-of-conduct) pod adresem <conduct@kubernetes.io>. W przypadku innych projektów, prosimy o kontakt z opiekunem projektu z CNCF lub z naszą mediatorką, Mishi Choudhary <mishi@linux.com>.
+
+Ten Kodeks Postępowania jest adaptacją Contributor Covenant
+(http://contributor-covenant.org) w wersji 1.2.0, dostępnej na
+http://contributor-covenant.org/version/1/2/0/
+
+### Kodeks postępowania dla wydarzeń organizowanych przez CNCF
+
+Wydarzenia organizowane przez CNCF podlegają [Kodeksowi Postępowania](https://events.linuxfoundation.org/code-of-conduct/) dostępnemu na stronie danego wydarzenia. Ma to na celu zapewnienie zgodności z powyższą polityką oraz zawiera szczegółowe wytyczne postępowania w przypadku zaistnienia niepożądanych incydentów.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -12,6 +12,7 @@ Other languages available:
 - [Russian/Русский](code-of-conduct-languages/ru.md)
 - [Portuguese/Português](code-of-conduct-languages/pt.md)
 - [Arabic/العربية](code-of-conduct-languages/ar.md)
+- [Polish/Polski](code-of-conduct-languages/pl.md)
 
 ### Contributor Code of Conduct
 


### PR DESCRIPTION
This translation of Code of Conduct is a part of Polish localization of Kubernetes documentation: https://github.com/kubernetes/website/pull/18419.