### PR TITLE
Add Bahasa Indonesia on the CoC list, update ID CoC maintainer

### DIFF
--- a/code-of-conduct-languages/id.md
+++ b/code-of-conduct-languages/id.md
@@ -1,26 +1,26 @@
-# Pedoman Perilaku Komunitas CNCF V1.0
+Pedoman Perilaku Komunitas CNCF V1.0
+------------------------------------
 
-## Kode Etik Kontributor
+### Kode Etik Kontributor
 
 Sebagai kontributor dan pengelola proyek ini, dan untuk kepentingan pembinaan sebuah komunitas yang terbuka dan ramah, kami berjanji untuk menghormati semua orang yang berkontribusi melalui masalah pelaporan, memposting permintaan fitur, memperbarui dokumentasi, mengajukan permintaan atau tambalan, dan kegiatan lainnya.
 
-Kami berkomitmen untuk menjadikan partisipasi dalam proyek ini pengalaman yang bebas dari pelecehan
-semua orang, terlepas dari tingkat pengalaman, jenis kelamin, identitas dan ekspresi gender orientasi seksual, kecacatan, penampilan pribadi, ukuran tubuh, ras, etnis, usia, agama, atau kebangsaan.
+Kami berkomitmen untuk menjadikan partisipasi dalam proyek ini pengalaman yang bebas dari pelecehan semua orang, terlepas dari tingkat pengalaman, jenis kelamin, identitas dan ekspresi gender, orientasi seksual, disabilitas, penampilan pribadi, ukuran tubuh, ras, etnis, usia, agama, atau kebangsaan.
 
-Contoh perilaku yang tidak dapat diterima oleh peserta termasuk:
+Contoh perilaku yang tidak dapat diterima oleh peserta termasuk di antaranya:
 
 - Penggunaan bahasa atau citra seksual
-- Menyerangan pribadi
-- Trolling atau menghina/merendahkan komentar
+- Penyerangan pribadi
+- Trolling atau komentar yang menghina/merendahkan
 - Pelecehan secara publik atau pribadi
 - Mempublikasikan informasi pribadi orang lain, seperti alamat fisik atau elektronik, tanpa izin tegas
 - Perilaku tidak etis atau tidak profesional lainnya.
 
-Pengelola proyek memiliki hak dan tanggung jawab untuk menghapus, mengedit, atau menolak komentar, komit, kode, suntingan wiki, isu, dan kontribusi lain yang tidak selaras dengan Kode Etik ini. Dengan mengadopsi Kode Etik ini, pengelola proyek berkomitmen untuk menerapkan prinsip-prinsip ini secara adil dan konsisten pada setiap aspek mengelola proyek ini. Pengelola proyek yang tidak mengikuti atau menegakkan Kode Perilaku dapat dihapus secara permanen dari tim proyek.
+Pengelola proyek memiliki hak dan tanggung jawab untuk menghapus, mengedit, atau menolak komentar, komit, kode, suntingan wiki, isu, dan kontribusi lain yang tidak selaras dengan Kode Etik ini. Dengan mengadopsi Kode Etik ini, pengelola proyek berkomitmen untuk menerapkan prinsip-prinsip ini secara adil dan konsisten pada setiap aspek pengelolaan proyek ini. Pengelola proyek yang tidak mengikuti atau menegakkan Kode Etik dapat dihapus secara permanen dari tim proyek.
 
 Kode etik ini berlaku baik di dalam ruang proyek maupun di ruang publik ketika seorang individu mewakili proyek atau komunitasnya.
 
-Contoh perilaku kasar, melecehkan, atau tidak dapat diterima di Kubernetes dapat dilaporkan dengan menghubungi [Komite Kode Etik Kubernetes](https://git.k8s.io/community/committee-code-of-conduct) melalui <conduct@kubernetes.io>. Untuk proyek lain, silakan hubungi pengelola proyek CNCF atau Dan Kohn <dan@linuxfoundation.org>.
+Contoh perilaku kasar, melecehkan, atau tidak dapat diterima di Kubernetes dapat dilaporkan dengan menghubungi [Komite Kode Etik Kubernetes](https://git.k8s.io/community/committee-code-of-conduct) melalui <conduct@kubernetes.io>. Untuk proyek lain, silakan hubungi pengelola proyek CNCF atau mediator kami, Mishi Choudhary <mishi@linux.com>.
 
 Kode Etik ini diadaptasi dari Covenant Contributor
 <http://contributor-covenant.org>, versi 1.2.0, tersedia di
@@ -28,4 +28,4 @@ Kode Etik ini diadaptasi dari Covenant Contributor
 
 ### Pedoman Perilaku Acara CNCF
 
-Acara CNCF ini diatur oleh Linux Foundation [Kode Etik](https://events.linuxfoundation.org/code-of-conduct/) yang tersedia di halaman acara. Ini dirancang agar kompatibel dengan kebijakan di atas dan juga mencakup rincian lebih lanjut tentang hal menanggapi insiden.
+Acara CNCF ini diatur oleh [Kode Etik](https://events.linuxfoundation.org/code-of-conduct/) Linux Foundation yang tersedia di halaman acara. Ini dirancang agar kompatibel dengan kebijakan di atas dan juga mencakup rincian lebih lanjut tentang hal menanggapi insiden.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -13,6 +13,7 @@ Other languages available:
 - [Portuguese/Português](code-of-conduct-languages/pt.md)
 - [Arabic/العربية](code-of-conduct-languages/ar.md)
 - [Polish/Polski](code-of-conduct-languages/pl.md)
+- [Indonesian/Bahasa Indonesia](code-of-conduct-languages/id.md)
 
 ### Contributor Code of Conduct
 


### PR DESCRIPTION
This PR add Bahasa Indonesia on Code of Conduct list, update maintainer to Mishi Choudhary, and some fix and rewording.