### PR TITLE
Update blog guidelines

### DIFF
--- a/blog-guidelines.md
+++ b/blog-guidelines.md
@@ -2,7 +2,7 @@
 
 ## CNCF Blog Overview ##
 
-The Cloud Native Computing Foundation (CNCF) blog serves as a channel for CNCF members, project maintainers of graduated and incubating projects, and ambassadors to share content with the community. 
+The Cloud Native Computing Foundation (CNCF) blog serves as a channel for CNCF members, project maintainers of graduated and incubating projects, CNCF Special Interest Groups (SIG), ambassadors to share content with the cloud native community.
 
 The content on our blog consists of:
 * Articles about graduated or incubating CNCF projects
@@ -10,33 +10,40 @@ The content on our blog consists of:
 * Stories about cloud native and CNCF project deployments
 * Use cases and success stories
 * Industry insight into cloud native adoption
-* Reports from CNCF events 
+* Reports from CNCF events
 
-Other topics are welcome, but it needs to have a direct link to the CNCF community.  
+Other topics are welcome, but it needs to have a direct link to the CNCF community.
 
-We accept content from CNCF members, project maintainers of graduated and incubating projects, and CNCF ambassadors.
+We accept content from CNCF members, project maintainers of graduated and incubating projects, CNCF SIGs, CNCF ambassadors.
+ 
+Project blog: Any blog post on a graduated or incubating project. This is written by or on behalf of the project. If written by a member about a project, this blog is classified as a Project blog. An example is a Harbor blog written by the VMware team. The blog is classified as a Project blog.
+
+Member blog: Any blog post written by a member. The blog must comply with the blog guidelines. A member can write about any open source project, including a CNCF Sandbox project. If a CNCF member writes solely about a CNCF graduated or incubating project and on behalf of the project, it is classified as a Project blog. If the blog contains information about a CNCF graduated or incubating project and includes information on how to do something with that project, it is classified as a Member blog.
+
+Special Interest Group (SIG) blog: A blog written by a SIG team member(s) is classified as a SIG blog. If a CNCF member writes a blog on behalf of the SIG, it is classified as a SIG blog. If a member writes a blog about a SIG, it is classified as a Member blog.
+
+Ambassador blog: This is a blog written by one of the CNCF Ambassadors.
+
+CNCF Staff: This is a blog written by a CNCF staff member. If the staff member is writing a blog on behalf of a project or a SIG, it is classified as a Project or SIG blog.
+
+Project internships and scholarship recipients: This is a blog that is written about a scholarship or internship related to a CNCF event or project.
 
 ## Content ##
-
 The CNCF blog audience is developers, IT operators, and cloud native and open source enthusiasts. Keep this in mind as you develop your blog content.
 
 Some things to think about:
 * Posts from members must be vendor-neutral. The post may mention a vendor’s name as it relates to specific open source projects, project deployments, adoption paths, their hosting of an in-person event or speaking at an event, or other indications of meaningful participation in the community, but it shouldn’t feel like an advertisement for your services or company. We do not accept announcements or press releases to the CNCF blog.
-* The most interesting posts are those that teach or show how to do something in a way others may not have thought of. 
+* The most interesting posts are how-to blogs, blogs with technical content, and those that teach or show how to do something in a way others may not have thought of.
 * Blog posts that show hurdles that were encountered and explain how they were overcome often do very well as the community is looking to learn.
-* How-to blogs and blogs with technical content are of interest to the developer audience in the community.
-* Content on how to choose between different technologies and how to accommodate different legacy issues and cloud platforms is a good way to highlight your learnings and share with the community. 
-* When showing upstreaming of a patch fixing an issue for others, link back to the Github issue, so readers can follow along. 
-* Critical commentary or broad issues must be approached with sensitivity, professionalism, and tact in a way that is beneficial and positive for the community. 
-
-Your post must be your content, but can be published elsewhere with a right to republish. All content should have an author and be published Creative Commons with Attribution.
+* Content on how to choose between different technologies and how to accommodate different legacy issues and cloud platforms is a good way to highlight your learnings and share with the community.
+* When showing upstreaming of a patch fixing an issue for others, link back to the Github issue, so readers can follow along.
+* Critical commentary or broad issues must be approached with sensitivity, professionalism, and tact in a way that is beneficial and positive for the community.
+* Your post must be your content, but can be published elsewhere with a right to republish. All content should have an author and be published Creative Commons with Attribution.
 
 ## Promotion ##
-
-Your blog will be shared on CNCF’s Twitter channel. Please feel free to retweet or share. 
+Your blog will be shared on CNCF’s Twitter channel. Please feel free to retweet or share.
 
 ## How to submit for consideration ##
-
 Please submit a brief summary and the topic of the post to blog@cncf.io for consideration. Or you can supply the blog for review. We will respond with a proposed date of publication or if it’s not suitable for the CNCF blog, we will provide feedback and direction.
 
-If you are submitting an article or presentation that already exists, please send it in its entirety with a note on the expressed permission from the owner of the content. 
+If you are submitting an article or presentation that already exists, please send it in its entirety with a note on the expressed permission from the owner of the content.


### PR DESCRIPTION
Edits to content for clarification
Added details for distinguishing between member, project, ambassador, SIG, staff, and intern / event blogs.