### PR TITLE
Make changes to "membership agreement" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo contains several documents related to the operation of the [Cloud Nati
 
 * The [charter](charter.md) under which CNCF operates
 * [Maintainer election policy](maintainers-election-policy.md) for the maintainer-elected TOC member and the two maintainers on the governing board
-* The [membership](membership.md) agreement
+* The [membership](cncf-membership-agreement.pdf) agreement
 * The [Code of Conduct](code-of-conduct.md) which has been translated into multiple languages
 
 ## Project Guidance


### PR DESCRIPTION
The third point in **Governance** where **membership** is highlighted links to an outdated link. When clicked, it shows:
<img width="1440" alt="Screenshot 2020-05-18 at 4 20 43 PM" src="https://user-images.githubusercontent.com/53044263/82205800-c28b4180-9924-11ea-9878-8c5281c9741b.png">

It should link to "cncf-membership-agreement.pdf". Made the necessary changes.