### PR TITLE
Update CoC to reference conduct@cncf.io

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -48,7 +48,7 @@ Conduct may be permanently removed from the project team.
 This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior in Kubernetes may be reported by contacting the [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) via <conduct@kubernetes.io>. For other projects, please contact a CNCF project maintainer or our mediator, Mishi Choudhary <mishi@linux.com>.
+Instances of abusive, harassing, or otherwise unacceptable behavior in Kubernetes may be reported by contacting the [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) via <conduct@kubernetes.io>. For other projects, please contact the CNCF staff via <conduct@cncf.io>. You can expect a response within three business days. In matters that require an outside mediator, we have retained Mishi Choudhary (mishi@linux.com).
 
 This Code of Conduct is adapted from the Contributor Covenant
 (http://contributor-covenant.org), version 1.2.0, available at


### PR DESCRIPTION
Signed-off-by: Chris Aniszczyk <caniszczyk@gmail.com>