### PR TITLE
Added Turkish to other languages available list in the code-of-conduct.md

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -16,6 +16,7 @@ Other languages available:
 - [Portuguese/Português](code-of-conduct-languages/pt.md)
 - [Russian/Русский](code-of-conduct-languages/ru.md)
 - [Spanish/Español](code-of-conduct-languages/es.md)
+- [Turkish/Türkçe](code-of-conduct-languages/tr.md)
 - [Ukrainian/Українська](code-of-conduct-languages/uk.md)
 - [Vietnamese/Tiếng Việt](code-of-conduct-languages/vi.md)
 


### PR DESCRIPTION
Turkish translation is already available, but there is no reference for that in the code-of-conduct.md document.