### PR TITLE
Update K3S maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -547,13 +547,13 @@ Sandbox,ChaosMesh,Siddon Tang,PingCAP,siddontang,https://github.com/chaos-mesh/c
 Sandbox,k3s,Brad Davidson,Rancher,brandond,https://github.com/rancher/k3s/blob/master/MAINTAINERS 
 ,,Brian Downs,Rancher,briandown,
 ,,Craig Jellick,Rancher,cjellick,
+,,Chris Wayne,Rancher,cwayne18,
+,,Derek Nola,Rancher,dereknola,
 ,,Jacob Blain Christen,Rancher,dweomer,
 ,,Erik Wilson,Rancher,erikwilson,
 ,,Hussein Galal,Rancher,galal-hussein,
 ,,Darren Shepherd,Rancher,ibuildthecloud,
-,,Menna Elmasry,Rancher,MonzElmasry,
 ,,Chris Kim,Rancher,Oats87,
-,,David Nuzik,Rancher,davidnuzik,
 Sandbox,Backstage,Patrik Oldsberg,Spotify,Rugvip,https://github.com/spotify/backstage/blob/master/OWNERS.md
 ,,Fredrik Adelöw ,Spotify,freben,
 ,,Raghunandan Balachandran,Spotify,soapraj,


### PR DESCRIPTION
Update the list of K3S maintainers as this has [changed recently](https://github.com/k3s-io/k3s/pull/3744/files).

Signed-off-by: David Nuzik <david.nuzik@rancher.com>