### PR TITLE
Add Paul Mellor as new Strimzi project maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -385,6 +385,7 @@ Sandbox,Strimzi,Jakub Scholz,Red Hat,scholzj,https://github.com/strimzi/strimzi-
 ,,Jakub Stejskal,Red Hat,Frawless ,
 ,,Sam Hawker,IBM,samuel-hawker,
 ,,Stanislav Knot,Red Hat,sknot-rh,
+,,Paul Mellor,Red Hat,PaulRMellor,
 Sandbox,KubeVirt,David Vossel,Red Hat,davidvossel,https://github.com/kubevirt/community/blob/master/MAINTAINERS.md
 ,,Vladik Romanovsky,Red Hat,vladikr,
 ,,Roman Mohr,Red Hat,rmohr,


### PR DESCRIPTION
This PR adds Paul Mellor as a new maintainer of the Strimzi project into the `project-maintainers.csv` file.