### PR TITLE
Update code of conduct to version 1.1

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,4 +1,4 @@
-## CNCF Community Code of Conduct v1.0
+## CNCF Community Code of Conduct v1.1
 
 Other languages available:
 - [Arabic/العربية](code-of-conduct-languages/ar.md)
@@ -22,42 +22,69 @@ Other languages available:
 
 ### Contributor Code of Conduct
 
-As contributors and maintainers of this project, and in the interest of fostering
+As contributors and maintainers in the CNCF community, and in the interest of fostering
 an open and welcoming community, we pledge to respect all people who contribute
 through reporting issues, posting feature requests, updating documentation,
 submitting pull requests or patches, and other activities.
 
-We are committed to making participation in this project a harassment-free experience for
-everyone, regardless of level of experience, gender, gender identity and expression,
+We are committed to making participation in the CNCF community a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression,
 sexual orientation, disability, personal appearance, body size, race, ethnicity, age,
 religion, or nationality.
 
-Examples of unacceptable behavior by participants include:
+## Scope 
 
-* The use of sexualized language or imagery
-* Personal attacks
-* Trolling or insulting/derogatory comments
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+### CNCF Events
+
+CNCF events, or events run by the Linux Foundation with professional events staff, are governed by the Linux Foundation [Events Code of Conduct](https://events.linuxfoundation.org/code-of-conduct/) available on the event page. This is designed to be used iconjunction with the CNCF Code of Conduct. 
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as physical or electronic addresses,
- without explicit permission
-* Other unethical or unprofessional conduct.
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
-Project maintainers have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are not
-aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers
-commit themselves to fairly and consistently applying these principles to every aspect
-of managing this project. Project maintainers who do not follow or enforce the Code of
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. 
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect
+of managing this project. 
+Project maintainers who do not follow or enforce the Code of
 Conduct may be permanently removed from the project team.
 
-This code of conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community.
+## Reporting 
 
-Instances of abusive, harassing, or otherwise unacceptable behavior in Kubernetes may be reported by contacting the [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) via <conduct@kubernetes.io>. For other projects, please contact the CNCF staff via <conduct@cncf.io>. You can expect a response within three business days. In matters that require an outside mediator, we have retained Mishi Choudhary (mishi@linux.com).
+For incidents occuring in the Kubernetes community, contact the [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) via <conduct@kubernetes.io>. You can expect a response within three business days.
+
+For other projects, please contact the CNCF staff via <conduct@cncf.io>. You can expect a response within three business days. 
+
+In matters that require an outside mediator, CNCF has retained Mishi Choudhary (mishi@linux.com). Use of an outside mediator can be requested when reporting or used at CNCF staff's discretion. In general, contacting <conduct@cncf.io> directly is preferred.
+
+
+## Enforcement 
+
+The Kubernetes project's [Code of Conduct Committee](https://github.com/kubernetes/community/tree/master/committee-code-of-conduct) enforces code of conduct issues. For all other projects, the CNCF enforces code of conduct issues.
+
+Both bodies try to resolve incidents without punishment, but may remove people from the project or CNCF communities at their discretion. 
+
+## Acknowledgements
 
 This Code of Conduct is adapted from the Contributor Covenant
-(http://contributor-covenant.org), version 1.2.0, available at
-http://contributor-covenant.org/version/1/2/0/
-
-### CNCF Events Code of Conduct
-
-CNCF events are governed by the Linux Foundation [Code of Conduct](https://events.linuxfoundation.org/code-of-conduct/) available on the event page. This is designed to be compatible with the above policy and also includes more details on responding to incidents.
+(http://contributor-covenant.org), version 2.0 available at
+http://contributor-covenant.org/version/2/0/code_of_conduct/


### PR DESCRIPTION
Updates the Code of Conduct to version 1.1, bringing in language from the [Contributor Covenant version 2.0](http://contributor-covenant.org/version/2/0/code_of_conduct/), improving clarity and scope. 

Signed-off-by: Celeste Horgan <celeste@cncf.io>