### PR TITLE
Add MetalLB as Sandbox

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -796,3 +796,6 @@ Sandbox,Akri,Kate Goldenring,Microsoft,kate-goldenring,https://github.com/deisla
 ,,Brian Fjeldstad,Microsoft,bfjelds,
 ,,Roaa Sakr,Microsoft,romoh,
 ,,Jiri Appl,Microsoft,jiria,
+Sandbox,MetalLB,Rodrigo Campos,Microsoft,rata,https://github.com/metallb/metallb/blob/main/CODEOWNERS
+,,Johannes Liebermann,Microsoft,johananl,
+,,Russell Bryant,Red Hat,russellb,


### PR DESCRIPTION
As requested [here][link] I'm adding MetalLB as a Sandbox project.

Please note that Dax is not included as I'm not sure the company he is working on. Will do a follow-up PR later to include him.

cc @johananl @russellb @daxmc99

[link]: https://github.com/cncf/toc/issues/720#issue-996232534