### PR TITLE
Extend Akri maintainers list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -793,6 +793,7 @@ Sandbox,Akri,Kate Goldenring,Microsoft,kate-goldenring,https://github.com/deisla
 ,,Brian Fjeldstad,Microsoft,bfjelds,
 ,,Roaa Sakr,Microsoft,romoh,
 ,,Jiri Appl,Microsoft,jiria,
+,,Edrick Wong,Microsoft,edrickwong,
 Sandbox,MetalLB,Rodrigo Campos,Microsoft,rata,https://github.com/metallb/metallb/blob/main/CODEOWNERS
 ,,Johannes Liebermann,Microsoft,johananl,
 ,,Russell Bryant,Red Hat,russellb,


### PR DESCRIPTION
Add @edrickwong to Akri Maintainers list. Enables access to CNCF Service Desk.