### PR TITLE
Add Giovanni Liva as Keptn Maintainer and remove Daniel Khan.

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -464,7 +464,7 @@ Sandbox,Keptn,Alois Reitbauer ,Dynatrace,AloisReitbauer ,https://github.com/kept
 ,,Jürgen Etzlstorfer,Dynatrace,jetzlstorfer ,
 ,,Christian Kreuzberger,Dynatrace,christian-kreuzberger-dtx ,
 ,,Johannes Bräuer,Dynatrace,johannes-b,
-,,Daniel Khan,Dynatrace,danielkhan,
+,,Giovanni Liva,Dynatrace,thisthat,
 Sandbox,Kudo,Alena Varkockova,,alenkacz,https://github.com/kudobuilder/kudo/blob/main/OWNERS
 ,,Gerred Dillon,,gerred,
 ,,Thomas Runyon,,runyontr,


### PR DESCRIPTION
Signed-off-by: Giovanni Liva <giovanni.liva@dynatrace.com>