### PR TITLE
Update cert-manager maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -635,10 +635,13 @@ Sandbox ,Cloud Development Kit for Kubernetes (cdk8s),Elad Ben-Israel ,,eladb,ht
 ,,Eli Polonsky ,,iliapolo,
 ,,Nathan Taber,,tabern,
 Sandbox,cert-manager,James Munnelly,Apple,munnerz,https://github.com/jetstack/cert-manager/blob/master/OWNERS
-,,Josh Van Leeuwen,JetStack,joshvanl,
+,,Josh Van Leeuwen,Jetstack,joshvanl,
 ,,Maartje Eyskens,,meyskens,
-,,Richard Wall,JetStack,wallrj,
-,,Jake Sanders,JetStack,jakexks,
+,,Richard Wall,Jetstack,wallrj,
+,,Jake Sanders,Jetstack,jakexks,
+,,Ashley Davis,Jetstack,SgtCoDFish,
+,,Irbe Krumina,Jetstack,irbekrm,
+,,Maël Valais,Jetstack,maelvls,
 Sandbox,OpenKruise,Fei Guo,Alibaba,Fei-Guo,https://github.com/openkruise/kruise/blob/master/MAINTAINERS.md
 ,,Siyu Wang,Alibaba,FillZpp,
 ,,Zhen Zhang,Alibaba,furykerry,


### PR DESCRIPTION
This includes fixing the spelling of "Jetstack" and adding all of the maintainers who're listed under the "OWNERS" file at:

https://github.com/jetstack/cert-manager/blob/5eabeb0020906f741da05122e4dee62d2d952657/OWNERS