### PR TITLE
Update CNI maintainers list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -156,10 +156,8 @@ Incubating,gRPC,Abhishek Kumar,Google,a11r,https://github.com/grpc/grpc/blob/mas
 ,,Yihuaz,Google,yihuazhang  ,
 ,,Zhouyihai Ding,Google,ZhouyihaiDing  ,
 Incubating,CNI,Bruce Ma,,mars1024,https://github.com/containernetworking/cni/blob/master/MAINTAINERS
-,,Bryan Boreham,Weaveworks,bboreham,
 ,,Casey Callendrello,Red Hat,squeed,
 ,,Dan Williams,Red Hat,dcbw,
-,,Gabe Rosenhouse,Pivotal,rosenhouse,
 ,,Matt Dupre,Tigera,matthewdupre,
 ,,Michael Cambria,Red Hat,mccv1r0,
 ,,Piotr Skarmuk,,jellonek,


### PR DESCRIPTION
@bboreham and I both stepped down as CNI maintainers this year.

References:
- Current source of truth: https://github.com/containernetworking/cni/blob/master/MAINTAINERS
- PR that removed me: https://github.com/containernetworking/cni/pull/863
- PR that removed Bryan: https://github.com/containernetworking/cni/pull/842

