### PR TITLE
Update kuma maintainers list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -505,6 +505,11 @@ Sandbox,Kuma,Jakub Dyszkiewicz,Kong,jakubdyszkiewicz,https://github.com/kumahq/k
 ,,Nikolay Nikolaev ,Kong,nickolaev,
 ,,Marco Palladino ,Kong,subnetmarco,
 ,,Austin Cawley-Edwards ,Ververica,austince,
+,,Bart Smykla ,Kong,bartsmykla,
+,,Charly Molter ,Kong,lahabana,
+,,James Peach ,Kong,jpeach,
+,,Mike Beaumont ,Kong,michaelbeaumont,
+,,Paul Parkanzky ,Kong,parkanzky,
 Sandbox,Parsec,Adam Parco,Docker,adamparco,https://github.com/parallaxsecond/parsec/blob/master/MAINTAINERS.toml
 ,,Sabree Blackmon,Docker,heavypackets,
 ,,Hugues de Valon,ARM,hug-dev,


### PR DESCRIPTION
Coming from https://github.com/cncf/foundation/pull/221#issuecomment-956367543

Updates the [Kuma](github.com/kumahq/kuma) maintainers list to the latest.

cc @idvoretskyi , @bartsmykla @lahabana @jpeach @michaelbeaumont @parkanzky 