### PR TITLE
updating maintainers list for SchemaHero

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -643,6 +643,9 @@ Sandbox,SchemaHero ,Marc Campbell ,Replicated,marccampbell,https://github.com/sc
 ,,Dmitriy Ivolgin,Replicated,divolgin,
 ,,Ethan Mosbaugh,Replicated,emosbaugh,
 ,,Andrew Lavery,Replicated,laverya,
+,,Dan Stough,Replicated,danstough,
+,,Salah Aldeen Al Saleh,Replicated,sgalsaleh,
+,,Treva Nichole Williams,Replicated,OGtrilliams,
 Sandbox ,Cloud Development Kit for Kubernetes (cdk8s),Elad Ben-Israel ,,eladb,https://github.com/awslabs/cdk8s/blob/master/OWNERS.md
 ,,Eli Polonsky ,,iliapolo,
 ,,Nathan Taber,,tabern,


### PR DESCRIPTION
Adding maintainers to SchemaHero project referenced from https://github.com/schemahero/schemahero/blob/main/OWNERS.md