### PR TITLE
project-maintainers: Update Kubernetes maintainers list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1,15 +1,20 @@
 ,Project,Maintainer Name ,Company,Github Name,OWNERS/MAINTAINERS
-Graduated,Kubernetes,Christoph Blecker,Red Hat,cblecker,https://github.com/kubernetes/steering#members
+Graduated,Kubernetes,Christoph Blecker,Red Hat,cblecker,https://git.k8s.io/steering#members
 ,,Paris Pittman,Apple,parispittman,
 ,,Bob Killen,Google,mrbobbytables,
 ,,Jordan Liggitt,Google,liggitt,
 ,,Davanum Srinivas,VMware,dims,
 ,,Stephen Augustus,Cisco,justaugustus,
 ,,Tim Pepper,VMware,tpepper,
-,Kubernetes Community Maintainers,Alison Dowdney,Independent,alisondy,https://github.com/kubernetes/community/blob/master/OWNERS
-,,Ihor Dvoretskyi,CNCF,idvoretskyi,
-,,Jaice Singer DuMars,Apple,jdumars,
+,Kubernetes: SIG Contributor Experience (non-voting),Alison Dowdney,Independent,alisondy,https://git.k8s.io/community/sig-contributor-experience#leadership
 ,,Nikhita Raghunath,VMware,nikhita,
+,Kubernetes: SIG K8s Infra (non-voting),Arnaud Meukam,Alter Way,ameukam,https://git.k8s.io/community/sig-k8s-infra#leadership
+,,Aaron Crickenberger,Google,spiffxp,
+,,Tim Hockin,Google,thockin,
+,Kubernetes: SIG Release (non-voting),Sascha Grunert,Red Hat,saschagrunert,https://git.k8s.io/community/sig-release#leadership
+,,Carlos Tadeu Panato Jr.,Mattermost,cpanato,
+,,Jeremy Rickard,Apple,jeremyrickard,
+,,Adolfo García Veytia,Mattermost,puerco,
 Graduated,Prometheus,Bartłomiej Płotka,Red Hat,bwplotka,https://prometheus.io/governance/#team-members
 ,,Ben Kochie,Reddit,superq,
 ,,Björn Rabenstein,Grafana Labs,beorn7,

--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1,14 +1,15 @@
 ,Project,Maintainer Name ,Company,Github Name,OWNERS/MAINTAINERS
 Graduated,Kubernetes,Christoph Blecker,Red Hat,cblecker,https://github.com/kubernetes/steering#members
 ,,Paris Pittman,Apple,parispittman,
-,,Nikhita Raghunath,VMware,nikhita,
 ,,Bob Killen,Google,mrbobbytables,
-,,Derek Carr,Red Hat,derekwaynecarr,
 ,,Jordan Liggitt,Google,liggitt,
 ,,Davanum Srinivas,VMware,dims,
-,Kubernetes Community Maintainers,Alison Dowdney,LinkedIn,alisondy,https://github.com/kubernetes/community/blob/master/OWNERS
+,,Stephen Augustus,Cisco,justaugustus,
+,,Tim Pepper,VMware,tpepper,
+,Kubernetes Community Maintainers,Alison Dowdney,Independent,alisondy,https://github.com/kubernetes/community/blob/master/OWNERS
 ,,Ihor Dvoretskyi,CNCF,idvoretskyi,
 ,,Jaice Singer DuMars,Apple,jdumars,
+,,Nikhita Raghunath,VMware,nikhita,
 Graduated,Prometheus,Bartłomiej Płotka,Red Hat,bwplotka,https://prometheus.io/governance/#team-members
 ,,Ben Kochie,Reddit,superq,
 ,,Björn Rabenstein,Grafana Labs,beorn7,


### PR DESCRIPTION
- maintainers(k8s): Update Kubernetes Steering Committee members 

  Following the [2021 Kubernetes Steering Committee election](https://kubernetes.io/blog/2021/11/08/steering-committee-results-2021/), the
  maintainers list should be updated to:

  Add new Steering Committee members:
  - @justaugustus
  - @tpepper
  
  Emeritus:
  - @derekwaynecarr

  @nikhita remains on the maintainers lists as a Kubernetes
  SIG Contributor Experience lead.

- maintainers(k8s): List non-voting members w/ Service Desk access
  
  Members of the following Special Interest Groups have access to
  Service Desk:
  - SIG Contributor Experience (@alisondy, @mrbobbytables, @cblecker, @nikhita)
  - SIG Kubernetes Infra (@ameukam, @dims, @spiffxp, @thockin)
  - SIG Release (@justaugustus, @saschagrunert, @cpanato, @jeremyrickard, @puerco)

  Also, removes the following listed maintainers:
  - @idvoretskyi 
  - @jdumars

  ref: https://git.k8s.io/steering/service-desk.md, https://github.com/kubernetes/steering/issues/222#issuecomment-964668362

Signed-off-by: Stephen Augustus <foo@auggie.dev>

cc: @parispittman @nikhita @amye @idvoretskyi 
Steering onboarding issue: https://github.com/kubernetes/steering/issues/219