### PR TITLE
docs: Tom Kerkhove is now representing Microsoft, instead of Codit

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -427,7 +427,7 @@ Sandbox,ChubaoFS,Haifeng Liu ,JD,bladehliu,https://github.com/chubaofs/chubaofs/
 Incubating,Keda,Jeff Hollan,Microsoft,jeffhollan,https://github.com/kedacore/keda/blob/master/MAINTAINERS.md
 ,,Ahmed ElSayed,Microsoft,ahmelsayed,
 ,,Zbynek Roubalik,Red Hat,zroubalik,
-,,Tom Kerkhove,Codit,tomkerkhove,
+,,Tom Kerkhove,Microsoft,tomkerkhove,
 Sandbox,Service Mesh Interface,Thomas Rampelberg,Buoyant Inc,grampelberg,https://github.com/servicemeshinterface/smi-spec/blob/master/CODEOWNERS
 ,,Lachlan Evenson,Microsoft,lachie83,
 ,,Lee Calcote,Layer5,leecalcote,


### PR DESCRIPTION
Tom Kerkhove is now representing Microsoft, instead of Codit

Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>