### PR TITLE
Add OpenTelemetry TC members to maintainers list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -369,6 +369,12 @@ Incubating,OpenTelemetry (Governance Committee),Alolita Sharma,Amazon,alolita,ht
 ,,Morgan James McLean,Splunk,mtwo,
 ,,Ted Young,Lightstep,tedsuo,
 ,,Yuri Shkuro,Facebook,yurishkuro,
+,OpenTelemetry (Technical Committee, excluding GC members),Armin Ruech,Dynatrace,arminru,https://github.com/open-telemetry/community/blob/master/community-members.md#technical-committee
+,,Carlos Alberto,Lightstep,carlosalberto,
+,,Josh MacDonald,Lightstep,jmacd,
+,,Josh Suereth,Google,jsuereth,
+,,Sergey Kanzhelev,Google,SergeyKanzhelev,
+,,Tigran Najaryan,Splunk,tigrannajaryan,
 Sandbox,OpenEBS,Amit Kumar Das,MayaData,AmitKumarDas,https://github.com/openebs/openebs/blob/master/MAINTAINERS
 ,,Jeffry Molanus,MayaData,gila,
 ,,Karthik Satchitanand,MayaData,ksatchit,


### PR DESCRIPTION
@amye we want to extend the maintainers list for OpenTelemetry to the TC members as well.