### PR TITLE
update tikv maintainer list in project-maintainers.csv

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -288,7 +288,7 @@ Graduated,TiKV,Siddon Tang,PingCAP,siddontang,https://github.com/tikv/tikv/blob/
 ,,Jay Li,PingCAP,busyjay,
 ,,Jinpeng Zhang,PingCAP,zhangjinpeng1987,
 ,,Wink Yao,PingCAP,winkyao,
-,,Xiaoguang Sun,Zhihu,sunxiaoguang,
+,,Xiaoguang Sun,PingCAP,sunxiaoguang,
 ,,Daobing Li,JD,lidaobing,
 ,,Fu Chen,Yidianzixun,fredchenbj,
 Incubating,CloudEvents,Doug Davis,IBM,duglin,n/a


### PR DESCRIPTION
According to https://github.com/tikv/community/pull/158, TiKV Maintainer: Sun xiaoguang has joined PingCAP. 

So I update his company information in project-maintainers.csv