### PR TITLE
Add fedepaol as MetalLB maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -894,6 +894,7 @@ Sandbox,Akri,Kate Goldenring,Microsoft,kate-goldenring,https://github.com/deisla
 Sandbox,MetalLB,Rodrigo Campos,Microsoft,rata,https://github.com/metallb/metallb/blob/main/CODEOWNERS
 ,,Johannes Liebermann,Microsoft,johananl,
 ,,Russell Bryant,Red Hat,russellb,
+,,Federico Paolinelli,Red Hat,fedepaol,
 Sandbox,Inclavare Containers,Jia Zhang,Alibaba,jiazhang0,https://github.com/alibaba/inclavare-containers/blob/master/MAINTAINERS.md
 ,,Liang Yang,Intel,YangLiang3,
 Sandbox,SuperEdge,Gerald Wang,Tencent,neweyes,https://github.com/superedge/superedge/blob/main/MAINTAINERS.md


### PR DESCRIPTION
Federico Paolinelli was added as MetalLB maintainer here:
	https://github.com/metallb/metallb/pull/993

Update this info here too.

cc @fedepaol 

Signed-off-by: Rodrigo Campos <rodrigo@kinvolk.io>