### PR TITLE
Update spiffe maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -302,10 +302,10 @@ Incubating,Falco,Mark Stemm,Sysdig,mstemm,https://github.com/falcosecurity/falco
 ,,Lorenzo Fontana,Sysdig,fntlnz,
 ,,Kris Nova,Sysdig,kris-nova,
 ,,Leonardo Grasso,Sysdig,leogr,
-Incubating,SPIFFE,Emiliano Berenbaum,Trustle Security,y2bishop2y,https://github.com/spiffe/spiffe/blob/master/CODEOWNERS
-,,Evan Gilman,VMWare,evan2645,
+Incubating,SPIFFE,Andres Vega,VMware,anvega,https://github.com/spiffe/spiffe/blob/master/CODEOWNERS
+,,Evan Gilman,VMware,evan2645,
 ,,Andrew Jessup,HPE,ajessup,
-,,Joseph Beda,VMware,jbeda,
+,,Andrew Moore,Uber,amoore877,
 ,,Frederick Kautz,Doc.ai,fkautz,
 ,,Justin Burke,Google,justinburke,
 ,,Spike Curtis,Tigera,spikecurtis,


### PR DESCRIPTION
Adds @anvega and @amoore877 to spiffe maintainers who replaced Joe Beda and Emiliano Berenbaum in the SPIFFE SC as recorded on https://github.com/spiffe/spiffe/pull/207. 

Signed-off-by: Andres Vega <andresv@vmware.com>