### PR TITLE
Remove jpkrohling from Jaeger

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -92,7 +92,6 @@ Graduated,Fluentd,Naotoshi SEO,ZOZO Technologies,sonots,https://github.com/fluen
 Graduated,Jaeger,Yuri Shkuro,Facebook,yurishkuro,https://github.com/uber/jaeger/blob/master/CODEOWNERS
 ,,Albert Teoh,,albertteoh,
 ,,Joe Elliot,Grafana Labs,joe-elliott,
-,,Juraci Paixão Kröhling,Grafana Labs,jpkrohling,
 ,,Pavol Loffay,Red Hat,pavolloffay,
 ,,Prithvi Raj,Uber,vprithvi,
 Graduated,Vitess,Alkin Tezuysal,PlanetScale,askdba,https://github.com/vitessio/vitess/blob/master/MAINTAINERS.md


### PR DESCRIPTION
Related to https://github.com/jaegertracing/jaeger/pull/3482

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
