### PR TITLE
Update project-maintainers.csv to fix Longhorn project status

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -445,7 +445,7 @@ Sandbox,KubeVirt,David Vossel,Red Hat,davidvossel,https://github.com/kubevirt/co
 ,,Fabian Deutsch,Red Hat,fabiand,
 ,,Ryan Hallisey,Nvidia,rthallisey,
 ,,Federico Gimenez,Red Hat,fgimenez,
-Sandbox,Longhorn,Sheng Yang,Rancher,yasker,https://github.com/longhorn/longhorn/blob/master/MAINTAINERS
+Incubating,Longhorn,Sheng Yang,SUSE,yasker,https://github.com/longhorn/longhorn/blob/master/MAINTAINERS
 ,,Shuo Wu,SUSE,shuo-wu,
 ,,Joshua Moody,SUSE,joshimoo,
 ,,David Ko,SUSE,innobead,


### PR DESCRIPTION
Fix Longhorn project status. Longhorn is now a project in `Incubating`.

Signed-off-by: Sheng Yang <sheng@yasker.org>