### PR TITLE
Update Harbor maintainers (esp. Community+Docs)

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -245,7 +245,9 @@ Graduated,Harbor,Daniel Jiang,VMware,reasonerjt,https://github.com/goharbor/comm
 ,,Pierre PÉRONNET,OVH Cloud,holyhope,
 ,,Alex Xu,VMware,xaleeks,
 ,,Tianon Gravi,InfoSiftr,tianon,
-,,Vadim Bauer,56K.Cloud,Vad1mo,
+,,Vadim Bauer,8gears,Vad1mo,
+,Harbor: SIG Community,Orlin Vasilev,VMware,OrlinVasilev,
+,Harbor: SIG Docs,Abigail McCarthy,VMware,a-mccarthy,
 Graduated,etcd,Ben Darnell,Cockroach Labs,bdarnell,https://github.com/etcd-io/etcd/blob/master/MAINTAINERS
 ,,Brandon Philips,Red Hat,philips,
 ,,Gyuho Lee,Amazon,gyuho,


### PR DESCRIPTION
This adds the new "SIG Community" and "SIG Docs" maintainers (Orlin and Abigail) and also fixes Vadim's affiliation.

(I did not add @hainingzhang under "SIG Community" since he's already a project maintainer, but if he should be listed twice I'm happy to update.)

cc @Vad1mo @OrlinVasilev @a-mccarthy