### PR TITLE
Update KubeVirt maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -434,10 +434,10 @@ Sandbox,KubeVirt,David Vossel,Red Hat,davidvossel,https://github.com/kubevirt/co
 ,,Roman Mohr,Red Hat,rmohr,
 ,,Vasiliy Ulyanov,SuSE,vasiliy-ul,
 ,,Stu Gott,Red Hat,stu-gott,
-,,Chris Calligari,Red Hat,mazzystr,
 ,,Fabian Deutsch,Red Hat,fabiand,
 ,,Ryan Hallisey,Nvidia,rthallisey,
 ,,Federico Gimenez,Red Hat,fgimenez,
+,,Andrew Burden,Red Hat,aburdenthehand,
 Incubating,Longhorn,Sheng Yang,SUSE,yasker,https://github.com/longhorn/longhorn/blob/master/MAINTAINERS
 ,,Shuo Wu,SUSE,shuo-wu,
 ,,Joshua Moody,SUSE,joshimoo,


### PR DESCRIPTION
Update to the KubeVirt maintainer's list:

- Remove Chris Calligari
- Add Andrew Burden

Signed-off-by: Stu Gott <stu-gott@users.noreply.github.com>