### PR TITLE
Update Tinkerbell maintainers list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -721,7 +721,9 @@ Sandbox,OpenKruise,Fei Guo,Alibaba,Fei-Guo,https://github.com/openkruise/kruise/
 ,,Zhen Zhang,Alibaba,furykerry,
 ,,Robert Everson,Lyft,reverson,
 ,,Henry Wang,Tencent,henrywangx,
-Sandbox,Tinkerbell ,Dan Finneran,Equinix Metal,thebsdbox,https://github.com/tinkerbell/.github/blob/master/MAINTAINERS.md
+Sandbox,Tinkerbell,Dan Finneran,Loft Labs,thebsdbox,https://github.com/tinkerbell/org/blob/main/MAINTAINERS.md
+,,Marky Jackson,Equinix Metal,markyjackson-taulia,
+,,Marques Johansson,Equinix Metal,displague,
 ,,Manuel Mendez,Equinix Metal,mmlb,
 Sandbox,Pravega,Flavio Junqueira,Pravega,fpj,https://github.com/pravega/.github/blob/main/MAINTAINERS
 ,,Tom Kaitchuck,Pravega,,


### PR DESCRIPTION
Updates Tinkerbell maintainers:
* Updates Dan Finneran's affiliations (cc @thebsdbox).
* Adds Marques Johansson (myself, @displague).
* Adds Marky Jackson (@markyjackson-taulia)


Corresponding changes are being made in https://github.com/tinkerbell/org/pull/15