### PR TITLE
[kubevirt] Sync data of maintainer rmohr

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -432,7 +432,7 @@ Sandbox,Strimzi,Jakub Scholz,Red Hat,scholzj,https://github.com/strimzi/strimzi-
 ,,Paul Mellor,Red Hat,PaulRMellor,
 Incubating,KubeVirt,David Vossel,Red Hat,davidvossel,https://github.com/kubevirt/community/blob/master/MAINTAINERS.md
 ,,Vladik Romanovsky,Red Hat,vladikr,
-,,Roman Mohr,Red Hat,rmohr,
+,,Roman Mohr,Google,rmohr,
 ,,Vasiliy Ulyanov,SuSE,vasiliy-ul,
 ,,Stu Gott,Red Hat,stu-gott,
 ,,Fabian Deutsch,Red Hat,fabiand,


### PR DESCRIPTION
Synchronizing kubevirt maintainer info.

xref https://github.com/kubevirt/community/pull/175