### PR TITLE
Adds Wiard van Rij as Thanos maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -396,6 +396,7 @@ Incubating,Thanos,Bartłomiej Płotka,Red Hat,bwplotka,https://github.com/thanos
 ,,Prem Saraswat,Red Hat,onprem,
 ,,Matthias Loibl,Polar Signals,metalmatze,
 ,,Ben Ye,ByteDance,yeya24,
+,,Wiard van Rij,Roku,wiardvanrij
 Incubating,Flux,Hidde Beydals,Weaveworks,hiddeco,https://github.com/fluxcd/community/blob/main/project/flux-project-maintainers.yaml
 ,,Michael Bridgen,Weaveworks,squaremo,
 ,,Stefan Prodan,Weaveworks,stefanprodan,


### PR DESCRIPTION
Signed-off-by: Wiard van Rij <wvanrij@roku.com>

https://github.com/thanos-io/thanos/pull/5113
