### PR TITLE
Removing Federico Gimenez from the KubeVirt maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -437,7 +437,6 @@ Incubating,KubeVirt,David Vossel,Red Hat,davidvossel,https://github.com/kubevirt
 ,,Stu Gott,Red Hat,stu-gott,
 ,,Fabian Deutsch,Red Hat,fabiand,
 ,,Ryan Hallisey,Nvidia,rthallisey,
-,,Federico Gimenez,Red Hat,fgimenez,
 ,,Andrew Burden,Red Hat,aburdenthehand,
 Incubating,Longhorn,Sheng Yang,SUSE,yasker,https://github.com/longhorn/longhorn/blob/master/MAINTAINERS
 ,,Shuo Wu,SUSE,shuo-wu,


### PR DESCRIPTION
Federico retired from his role as a KubeVirt maintainer. 
Merged KubeVirt Community PR: https://github.com/kubevirt/community/pull/176