### PR TITLE
Add aidandelaney as Buildpacks maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -324,7 +324,8 @@ Incubating,Cortex,Bryan Boreham,Grafana Labs,bboreham,https://github.com/cortexp
 ,,Marco Pracucci,Grafana Labs,pracucci,
 ,,Peter Štibraný,Grafana Labs,pstibrany,
 ,,Tom Wilkie,Grafana Labs,tomwilkie,
-Incubating,Buildpacks,Ben Hale,VMware,nebhale,https://github.com/buildpacks/community/blob/main/OWNERS
+Incubating,Buildpacks,Aidan Delaney,Bloomberg,aidandelaney,https://github.com/buildpacks/community/blob/main/OWNERS
+,,Ben Hale,VMware,nebhale,
 ,,David Freilich,AppsFlyer,dfreilich,
 ,,Emily Casey,VMware,ekcasey,
 ,,Javier Romero,VMware,jromero,


### PR DESCRIPTION
Aidan Delaney has been added to the buildpacks
leadership team. Reflect this in the CNCF project
maintainers document.