### PR TITLE
Add Austin Parker

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -383,6 +383,7 @@ Incubating,OpenTelemetry (Governance Committee),Alolita Sharma,Amazon,alolita,ht
 ,,Josh Suereth,Google,jsuereth,
 ,,Sergey Kanzhelev,Google,SergeyKanzhelev,
 ,,Tigran Najaryan,Splunk,tigrannajaryan,
+,OpenTelemetry (Communications SIG),Austin Parker,Lightstep,austinlparker,https://github.com/open-telemetry/community/blob/main/community-members.md#docs-and-website
 Sandbox,OpenEBS,Amit Kumar Das,MayaData,AmitKumarDas,https://github.com/openebs/openebs/blob/master/MAINTAINERS
 ,,Jeffry Molanus,MayaData,gila,
 ,,Karthik Satchitanand,MayaData,ksatchit,


### PR DESCRIPTION
Adding Austin Parker as maintainer of OpenTelemetry Communications SIG 

cc @mtwo

Signed-off-by: Austin Parker <austin@ap2.io>