### PR TITLE
Update Spelling / Employer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -291,7 +291,7 @@ Incubating,CloudEvents,Doug Davis,IBM,duglin,https://github.com/cloudevents/spec
 Incubating,Falco,Mark Stemm,Sysdig,mstemm,https://github.com/falcosecurity/falco/blob/master/OWNERS
 ,,Leonardo Di Donato,Sysdig,leodido,
 ,,Lorenzo Fontana,Sysdig,fntlnz,
-,,Kris Nova,Sysdig,kris-nova,
+,,Kris Nóva,Independent,kris-nova,
 ,,Leonardo Grasso,Sysdig,leogr,
 ,,Jason Dellaluce,Sysdig,jasondellaluce,
 Incubating,SPIFFE,Andres Vega,VMware,anvega,https://github.com/spiffe/spiffe/blob/main/CODEOWNERS


### PR DESCRIPTION
My employer does not define me as a computer scientist.

They are merely a vehicle to my retirement that stands in between my otherwise lifelong collaborative computer science work for the greater humanity and the united state's unique relationship with debt and worker exploitation.

Additionally my name was spelled wrong and that specific employer was very outdated. Please merge.

Signed-off-by: Kris Nóva <kris@nivenly.com>