### PR TITLE
Update Tinkerbell maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -722,10 +722,10 @@ Sandbox,OpenKruise,Fei Guo,Alibaba,Fei-Guo,https://github.com/openkruise/kruise/
 ,,Zhen Zhang,Alibaba,furykerry,
 ,,Robert Everson,Lyft,reverson,
 ,,Henry Wang,Tencent,henrywangx,
-Sandbox,Tinkerbell,Dan Finneran,Loft Labs,thebsdbox,https://github.com/tinkerbell/org/blob/main/MAINTAINERS.md
-,,Marky Jackson,Equinix Metal,markyjackson-taulia,
+Sandbox,Tinkerbell,Jacob Weinstock,Amazon Web Services,jacobweinstock,https://github.com/tinkerbell/org/blob/main/ADMINS.md
+,,Jeremy Tanner,Equinix Metal,jeremytanner,
 ,,Marques Johansson,Equinix Metal,displague,
-,,Manuel Mendez,Equinix Metal,mmlb,
+,,Matt Anderson,Equinix Metal,matoszz,
 Sandbox,Pravega,Flavio Junqueira,Pravega,fpj,https://github.com/pravega/.github/blob/main/MAINTAINERS
 ,,Tom Kaitchuck,Pravega,tkaitchuck,
 ,,Derek Moore,Pravega,derekm,


### PR DESCRIPTION
Hi there! This is an update to the Tinkerbell maintainers.

Removes Dan Finneran (cc, @thebsdbox).
Removes Marky Jackson (cc, @markyjackson-taulia).
Removes Manuel Mendez (cc, @mmlb).
Adds Jacob Weinstock (myself, @jacobweinstock).
Adds Jeremy Tanner (cc, @jeremytanner).
Adds Matt Anderson (cc, @matoszz).

Corresponding changes were made in tinkerbell/org#20