### PR TITLE
docs: bulk updates Falco maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -289,12 +289,18 @@ Incubating,CloudEvents,Doug Davis,IBM,duglin,https://github.com/cloudevents/spec
 ,,Mark Peek,VMware,markpeek,
 ,,Ken Owens,Mastercard,kenowens12,
 ,,Klaus Deissner,SAP,deissnerk,
-Incubating,Falco,Mark Stemm,Sysdig,mstemm,https://github.com/falcosecurity/falco/blob/master/OWNERS
-,,Leonardo Di Donato,Sysdig,leodido,
-,,Lorenzo Fontana,Sysdig,fntlnz,
-,,Kris Nova,Sysdig,kris-nova,
-,,Leonardo Grasso,Sysdig,leogr,
+Incubating,Falco,Andrea Terzolo,Polytechnic of Turin,andreagit97,https://github.com/falcosecurity/evolution/blob/main/MAINTAINERS.md#core-maintainers
+,,Carlos Tadeu Panato Junior,Chainguard,cpanato,
+,,Federico Di Pierro,Sysdig,fededp,
+,,Grzegorz Nosek,Sysdig,gnosek,
 ,,Jason Dellaluce,Sysdig,jasondellaluce,
+,,Leonardo Grasso,Sysdig,leogr,
+,,Luca Guerra,Sysdig,lucaguerra,
+,,Mark Stemm,Sysdig,mstemm,
+,,Massimiliano Giovagnoli,Clastix,maxgio92,
+,,Mauro Ezequiel Moltrasio,RedHat,molter73,
+,,Michele Zuccala,Sysdig,zuc,
+,,Thomas Labarussias,Sysdig,issif,
 Incubating,SPIFFE,Andres Vega,VMware,anvega,https://github.com/spiffe/spiffe/blob/main/CODEOWNERS
 ,,Evan Gilman,VMware,evan2645,
 ,,Andrew Jessup,HPE,ajessup,


### PR DESCRIPTION
Hey @amye 

The last update of Falco governance precisely defines the [core maintainers' role](https://github.com/falcosecurity/evolution/blob/main/GOVERNANCE.md#core-maintainers). They are responsible for overseeing the overall project's health and speaking on behalf of the project.

The core maintainers list is now published at :point_down:  
https://github.com/falcosecurity/evolution/blob/main/MAINTAINERS.md#core-maintainers

So, this PR updates in bulk the Falco core maintainers list in this repository.

We also kindly ask you to update the `cncf-falco-maintainers@lists.cncf.io` accordingly.

Thank you :pray: 
Leo