### PR TITLE
Update Chaos Mesh maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -630,6 +630,7 @@ Sandbox,ChaosMesh,Cwen Yin,PingCAP,cwen0,https://github.com/chaos-mesh/chaos-mes
 ,,Calvin Weng,PingCAP,dcalvin,
 ,,Ben Ye,ByteDance,yeya24,
 ,,Hengliang Tan,Xpeng Motors,Gallardot,
+,,Zhiqiang Zhou,Individual,STRRL  
 Sandbox,k3s,Brad Davidson,SUSE,brandond,https://github.com/rancher/k3s/blob/master/MAINTAINERS
 ,,Brian Downs,SUSE,briandowns,
 ,,Craig Jellick,SUSE,cjellick,


### PR DESCRIPTION
According to the recent change in https://github.com/chaos-mesh/chaos-mesh/pull/3512, we updated the list to add Zhiqiang Zhou (@STRRL) as a Chaos Mesh maintainer. 

Signed-off-by: Calvin Weng <wenghao@pingcap.com>