### PR TITLE
Add Austin Parker

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -376,6 +376,7 @@ Incubating,OpenTelemetry (Governance Committee),Alolita Sharma,Amazon,alolita,ht
 ,,Morgan James McLean,Splunk,mtwo,
 ,,Ted Young,Lightstep,tedsuo,
 ,,Yuri Shkuro,Facebook,yurishkuro,
+,OpenTelemetry (Community Maintainer),Austin Parker,Lightstep,austinlparker,https://github.com/open-telemetry/community/blob/main/community-members.md#community-management
 ,OpenTelemetry (Technical Committee excluding GC members),Armin Ruech,Dynatrace,arminru,https://github.com/open-telemetry/community/blob/master/community-members.md#technical-committee
 ,,Carlos Alberto,Lightstep,carlosalberto,
 ,,Josh MacDonald,Lightstep,jmacd,


### PR DESCRIPTION
Recently, OpenTelemetry Governance Committee has adopted a new project-level maintainer role of 'Community Maintainer'. This role is intended to act with the GC's blessing to support and maintain the project community of end-users and contributors. To this end, they require Service Desk access, and to receive project/event-related communications from the CNCF.

Please see https://github.com/open-telemetry/community/blob/main/governance-charter.md#community-manager-role for more information.

Signed-off-by: Austin Parker <austin@ap2.io>