### PR TITLE
Add Kured as a Sandbox project

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1096,3 +1096,8 @@ Sandbox,Hexa Policy Orchestrator,Gerry Gebel,Strata Identity,ggebel,https://gith
 ,,Hunter Gillane, Initial Capacity, gnarargs,
 ,,Tyson Gern, Initial Capacity, tygern,
 ,,Damien Le Berrigaud, Initial Capacity, dam5s,
+Sandbox,Kured,Christian Kotzbauer,nerdware,ckotzbauer,https://github.com/weaveworks/kured/blob/main/MAINTAINERS
+,,Daniel Holbach,Weaveworks,dholbach,
+,,Hidde Beydals,Weaveworks,hiddeco,
+,,Jean-Phillipe Evrard,TLaaS,evrardjp,
+,,Jack Francis,Microsoft,jackfrancis,


### PR DESCRIPTION
As of yesterday, Kured is a Sandbox project: https://lists.cncf.io/g/cncf-toc/message/7501

We will start on the move to a new GH org, etc in the next days.

cc @ckotzbauer @hiddeco @evrardjp @jackfrancis to please look over your details in this PR.

Signed-off-by: Daniel Holbach <daniel@holba.ch>