### PR TITLE
Fix typo in evrardjp fullname

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1099,5 +1099,5 @@ Sandbox,Hexa Policy Orchestrator,Gerry Gebel,Strata Identity,ggebel,https://gith
 Sandbox,Kured,Christian Kotzbauer,nerdware,ckotzbauer,https://github.com/weaveworks/kured/blob/main/MAINTAINERS
 ,,Daniel Holbach,Weaveworks,dholbach,
 ,,Hidde Beydals,Weaveworks,hiddeco,
-,,Jean-Phillipe Evrard,TLaaS,evrardjp,
+,,Jean-Philippe Evrard,TLaaS,evrardjp,
 ,,Jack Francis,Microsoft,jackfrancis,


### PR DESCRIPTION
Without this, the github username doesn't reflect my name. This should fix it.