### PR TITLE
Add OpenFGA Maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1101,3 +1101,14 @@ Sandbox,Kured,Christian Kotzbauer,nerdware,ckotzbauer,https://github.com/weavewo
 ,,Hidde Beydals,Weaveworks,hiddeco,
 ,,Jean-Philippe Evrard,TLaaS,evrardjp,
 ,,Jack Francis,Microsoft,jackfrancis,
+Sandbox, OpenFGA, Adrian Tam, Okta, adriantam
+,,Andres Aguiar, Okta, aaguiarz
+,,Craig Pastro, Okta, craigpastro
+,,Damian Schenkelman, Okta, dschenkelman
+,,Jakub Hertyk, Okta, curfew-marathon
+,,Jonathan Whitaker, Okta, jon-whit
+,,Maria Ines Parnisari, Okta, miparnisari
+,,Mat Dupont, Okta, matldupont
+,,Matthew Pereira, Okta, matthewpereira
+,,Raghd Hamzeh, Okta, rhamzeh
+,,Yamil Asusta, Okta, elbuo8

--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1101,14 +1101,14 @@ Sandbox,Kured,Christian Kotzbauer,nerdware,ckotzbauer,https://github.com/weavewo
 ,,Hidde Beydals,Weaveworks,hiddeco,
 ,,Jean-Philippe Evrard,TLaaS,evrardjp,
 ,,Jack Francis,Microsoft,jackfrancis,
-Sandbox, OpenFGA, Adrian Tam, Okta, adriantam
-,,Andres Aguiar, Okta, aaguiarz
-,,Craig Pastro, Okta, craigpastro
-,,Damian Schenkelman, Okta, dschenkelman
-,,Jakub Hertyk, Okta, curfew-marathon
-,,Jonathan Whitaker, Okta, jon-whit
-,,Maria Ines Parnisari, Okta, miparnisari
-,,Mat Dupont, Okta, matldupont
-,,Matthew Pereira, Okta, matthewpereira
-,,Raghd Hamzeh, Okta, rhamzeh
-,,Yamil Asusta, Okta, elbuo8
+Sandbox, OpenFGA, Adrian Tam, Okta, adriantam, https://github.com/openfga/community/blob/main/MAINTAINERS
+,,Andres Aguiar, Okta, aaguiarz,
+,,Craig Pastro, Okta, craigpastro,
+,,Damian Schenkelman, Okta, dschenkelman,
+,,Jakub Hertyk, Okta, curfew-marathon,
+,,Jonathan Whitaker, Okta, jon-whit,
+,,Maria Ines Parnisari, Okta, miparnisari,
+,,Mat Dupont, Okta, matldupont,
+,,Matthew Pereira, Okta, matthewpereira,
+,,Raghd Hamzeh, Okta, rhamzeh,
+,,Yamil Asusta, Okta, elbuo8,


### PR DESCRIPTION
Add OpenFGA Maintainers

For https://github.com/cncf/toc/issues/921
For https://github.com/openfga/community/issues/33

> Create maintainer list + add to aggregated https://maintainers.cncf.io/ list by submitting a PR to it

Signed-off-by: Andrés Aguiar <andres.aguiar@auth0.com>