### PR TITLE
Strimzi: Add Lukas Kral and Maros Orsak to maintainers list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -428,6 +428,8 @@ Sandbox,Strimzi,Jakub Scholz,Red Hat,scholzj,https://github.com/strimzi/strimzi-
 ,,Sam Hawker,IBM,samuel-hawker,
 ,,Stanislav Knot,Red Hat,sknot-rh,
 ,,Paul Mellor,Red Hat,PaulRMellor,
+,,Lukáš Král,Red Hat,im-konge,
+,,Maroš Orsák,Red Hat,see-quick,
 Incubating,KubeVirt,David Vossel,Red Hat,davidvossel,https://github.com/kubevirt/community/blob/master/MAINTAINERS.md
 ,,Vladik Romanovsky,Red Hat,vladikr,
 ,,Roman Mohr,Google,rmohr,


### PR DESCRIPTION
This PR adds Lukas Kral and Maros Orsak as new maintainers for Strimzi.io project.