### PR TITLE
Update Turkish Code of Conduct from v1.0 to v1.2

### DIFF
--- a/code-of-conduct-languages/tr.md
+++ b/code-of-conduct-languages/tr.md
@@ -1,5 +1,4 @@
-CNCF Topluluğu Davranış Kuralları v1.0
-------------------------------------------
+## CNCF Topluluğu Davranış Kuralları v1.2
 
 ### Katkıda Bulunanlar için Davranış Kuralları
 
@@ -7,24 +6,52 @@ Bu projeye katkıda bulunanlar ve proje geliştiricileri olarak açık ve misafi
 
 Deneyim seviyesi, cinsiyet, cinsel kimlik ve ifade, cinsel yönelim, engellilik, kişisel görünüm, vücut ölçüsü, ırk, etnik köken, yaş, din veya milliyetten bağımsız olarak bu projeye katılımı herkes için tacizden arındırılmış bir deneyim haline getirmeye kararlıyız.
 
-Kabul edilemez katılımcı davranış örnekleri şunları içerir:
+## Kapsam
 
-* Cinselleştirilmiş dil veya görsellerin kullanımı
-* Kişisel saldırılar
-* Trolleme veya aşağılayıcı/hakaret içeren yorumlar
-* Açıktan veya gizli taciz
-* Açık izinleri olmadan başkalarının fiziksel veya elektronik adresleri gibi özel bilgilerini yayınlama
-* Etik veya profesyonel olmayan diğer davranışlar.
+Bu davranış kuralları, bir kişi projeyi veya topluluğu temsil ettiğinde hem proje alanlarında hem de kamusal alanlarda geçerlidir.
 
-Proje geliştiricileri; yorumları, gönderim mesajlarını, kodları, wiki düzenlemelerini, sorunları ve bu Davranış Kuralları’na uygun olmayan diğer katkıları kaldırma, düzenleme veya reddetme hakkına ve sorumluluğuna sahiptir. Proje geliştiricileri bu Davranış Kuralları’nı benimseyerek, bu ilkeleri proje yönetiminin her yönüne adil ve istikrarlı bir şekilde uygulamaya kendilerini adamışlardır. Davranış Kuralları’na uymayan veya bunları uygulamayan proje geliştiricileri, proje ekibinden kalıcı olarak çıkarılabilir.
+### CNCF Etkinlikleri
 
-Bu Davranış Kuralları, kişinin projeyi veya topluluğunu temsil etmesi durumunda proje içinde olduğu kadar kamusal alanda da geçerlidir.
+CNCF etkinlikleri veya Linux Vakfı tarafından profesyonel etkinlik personeli ile yürütülen, Linux Vakfı tarafından yönetilen etkinlikler [Etkinlik Davranış Kuralları](https://events.linuxfoundation.org/code-of-conduct/) etkinlik sayfasında bulunur. Bu, CNCF Davranış Kuralları ile birlikte kullanılmak üzere tasarlanmıştır.
 
-Kubernetes'te meydana gelen zorbalık, taciz edici veya başka bir şekilde kabul edilemez davranış örnekleri, <conduct@kubernetes.io> aracılığıyla [Kubernetes Davranış Kuralları Komitesi](https://github.com/kubernetes/community/tree/master/committee-code-of-conduct) ile iletişime geçilerek bildirilebilir. Diğer projeler için lütfen bir CNCF proje geliştiricisi veya aracımız Mishi Choudhary ile <mishi@linux.com> adresinden iletişime geçin.
+## Standartlarımız
 
-Bu Davranış Kuralları Contributor Covenant'dan (http://contributor-covenant.org) uyarlanmıştır, sürüm 1.2.0’a http://contributor-covenant.org/version/1/2/0/ adresinden ulaşılabilir.
+Olumlu bir ortama katkıda bulunan davranış örnekleri şunları içerir:
 
-### CNCF Etkinlikleri Davranış Kuralları
+* Diğer insanlara karşı empati ve nezaket göstermek
+* Farklı görüşlere, bakış açılarına ve deneyimlere saygılı olmak
+* Yapıcı geri bildirim vermek ve incelikle kabul etmek
+* Sorumluluğu kabul etmek ve hatalarımızdan etkilenenlerden özür dilemek ve deneyimden öğrenme
+* Sadece bireyler olarak bizim için değil, tüm toplum için en iyisinin ne olduğuna odaklanmak
 
-CNCF etkinlikleri, etkinlik sayfasında bulunan Linux Vakfı [Davranış Kuralları](https://events.linuxfoundation.org/about/code-of-conduct/) ile yönetilir. Bu kurallar yukarıda belirtilen politikayla uyumlu olacak şekilde tasarlanmıştır ve ayrıca olaylara nasıl müdahale edileceği konusunda daha fazla ayrıntı içerir.
+Kabul edilemez davranış örnekleri şunları içerir:
 
+* Cinselleştirilmiş dil veya imge kullanımı ve her türlü cinsel ilgi veya ilerleme
+* Trolleme, hakaret veya aşağılayıcı yorumlar ve kişisel veya siyasi saldırılar
+* Kamusal veya özel taciz
+* Başkalarının fiziksel veya e-posta adresi gibi özel bilgilerini açık izinleri olmadan yayınlamak
+* Profesyonel bir ortamda makul olarak uygunsuz kabul edilebilecek diğer davranışlar
+
+Proje sahipleri, bu Davranış Kuralları ile uyumlu olmayan yorumları, taahhütleri, kodları, wiki düzenlemelerini, sorunları ve diğer katkıları kaldırma, düzenleme veya reddetme hakkına ve sorumluluğuna sahiptir.
+Proje yürütücüleri, bu Davranış Kurallarını benimseyerek, bu ilkeleri bu projeyi yönetmenin her yönüne adil ve tutarlı bir şekilde uygulamayı taahhüt eder.
+Davranış Kurallarını takip etmeyen veya uygulamayan proje yürütücüleri, proje ekibinden kalıcı olarak çıkarılabilir.
+
+## Raporlama
+
+Kubernetes topluluğunda meydana gelen olaylar için <conduct@kubernetes.io> aracılığıyla [Kubernetes Davranış Kuralları Komitesi](https://git.k8s.io/community/committee-code-of-conduct) ile iletişime geçin. Üç iş günü içinde yanıt bekleyebilirsiniz.
+
+Diğer projeler veya projeden bağımsız olan veya birden fazla CNCF projesini etkileyen olaylar için lütfen conduct@cncf.io aracılığıyla [CNCF Davranış Kuralları Komitesi](https://www.cncf.io/conduct/committee/) ile iletişime geçin. Alternatif olarak, raporunuzu göndermek için [CNCF Davranış Kuralları Komitesinin](https://www.cncf.io/conduct/committee/) herhangi bir üyesiyle iletişime geçebilirsiniz. Bir raporun isimsiz olarak nasıl gönderileceği de dahil olmak üzere bir raporun nasıl gönderileceğine ilişkin daha ayrıntılı talimatlar için lütfen [Olay Çözüm Prosedürlerimize](https://www.cncf.io/conduct/procedures/) bakın. Üç iş günü içinde yanıt bekleyebilirsiniz.
+
+## Yürütme
+
+Kubernetes projesinin [Davranış Kuralları Komitesi](https://github.com/kubernetes/community/tree/master/committee-code-of-conduct), Kubernetes projesi için davranış kuralları konularını uygular.
+
+Kendi Davranış Kuralları Komitesi veya diğer Davranış Kuralları olay müdahale görevlileri olmayan tüm projeler ve projeden bağımsız olan veya birden fazla projeyi etkileyen olaylar için [CNCF Davranış Kuralları Komitesi](https://www.cncf.io/conduct/committee/) davranış kuralları konularını zorunlu kılar. Daha fazla bilgi için bizim [Yargı Yetkisi ve Yükseltme Politikamıza](https://www.cncf.io/conduct/jurisdiction/) bakın.
+
+Her iki kurum da olayları cezalandırmadan çözmeye çalışır, ancak kendi takdirlerine bağlı olarak insanları projeden veya CNCF topluluklarından çıkarabilir.
+
+## Teşekkür
+
+Bu Davranış Kuralları, Katılımcı Sözleşmesi'nden uyarlanmıştır
+(http://contributor-covenant.org), sürüm 2.0 şu adreste mevcuttur:
+http://contributor-covenant.org/version/2/0/code_of_conduct/


### PR DESCRIPTION
Updated Turkish version of Code of Conduct from v1.0 to v1.2 considering the latest version of English Code of Conduct file. (#375) 

Signed-off-by: Enes ahmedenesturan@gmail.com