### PR TITLE
project-maintainers: Update Kubernetes maintainers list (2023)

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -2,14 +2,15 @@
 Graduated,Kubernetes,Christoph Blecker,Red Hat,cblecker,https://git.k8s.io/steering#members
 ,,Paris Pittman,Apple,parispittman,
 ,,Bob Killen,Google,mrbobbytables,
-,,Jordan Liggitt,Google,liggitt,
-,,Davanum Srinivas,VMware,dims,
 ,,Stephen Augustus,Cisco,justaugustus,
 ,,Tim Pepper,VMware,tpepper,
+,,Benjamin Elder,Google,BenTheElder,
+,,Nabarun Pal,VMware,palnabarun,
 ,Kubernetes: SIG Contributor Experience (non-voting),Alison Dowdney,Independent,alisondy,https://git.k8s.io/community/sig-contributor-experience#leadership
 ,,Nikhita Raghunath,VMware,nikhita,
 ,Kubernetes: SIG K8s Infra (non-voting),Arnaud Meukam,Alter Way,ameukam,https://git.k8s.io/community/sig-k8s-infra#leadership
 ,,Aaron Crickenberger,Google,spiffxp,
+,,Davanum Srinivas,AWS,dims,
 ,,Tim Hockin,Google,thockin,
 ,Kubernetes: SIG Release (non-voting),Sascha Grunert,Red Hat,saschagrunert,https://git.k8s.io/community/sig-release#leadership
 ,,Carlos Tadeu Panato Jr.,Mattermost,cpanato,

--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1,4 +1,4 @@
-﻿,Project,Maintainer Name ,Company,Github Name,OWNERS/MAINTAINERS
+﻿,Project,Maintainer Name,Company,Github Name,OWNERS/MAINTAINERS
 Graduated,Kubernetes,Christoph Blecker,Red Hat,cblecker,https://git.k8s.io/steering#members
 ,,Paris Pittman,Apple,parispittman,
 ,,Bob Killen,Google,mrbobbytables,
@@ -6,16 +6,16 @@ Graduated,Kubernetes,Christoph Blecker,Red Hat,cblecker,https://git.k8s.io/steer
 ,,Tim Pepper,VMware,tpepper,
 ,,Benjamin Elder,Google,BenTheElder,
 ,,Nabarun Pal,VMware,palnabarun,
-,Kubernetes: SIG Contributor Experience (non-voting),Alison Dowdney,Independent,alisondy,https://git.k8s.io/community/sig-contributor-experience#leadership
+,Kubernetes: SIG Contributor Experience (non-voting),Josh Berkus,Red Hat,jberkus,https://git.k8s.io/community/sig-contributor-experience#leadership
 ,,Nikhita Raghunath,VMware,nikhita,
-,Kubernetes: SIG K8s Infra (non-voting),Arnaud Meukam,Alter Way,ameukam,https://git.k8s.io/community/sig-k8s-infra#leadership
+,Kubernetes: SIG K8s Infra (non-voting),Arnaud Meukam,VMware,ameukam,https://git.k8s.io/community/sig-k8s-infra#leadership
 ,,Aaron Crickenberger,Google,spiffxp,
 ,,Davanum Srinivas,AWS,dims,
 ,,Tim Hockin,Google,thockin,
 ,Kubernetes: SIG Release (non-voting),Sascha Grunert,Red Hat,saschagrunert,https://git.k8s.io/community/sig-release#leadership
-,,Carlos Tadeu Panato Jr.,Mattermost,cpanato,
-,,Jeremy Rickard,Apple,jeremyrickard,
-,,Adolfo García Veytia,Mattermost,puerco,
+,,Carlos Tadeu Panato Jr.,Chainguard,cpanato,
+,,Jeremy Rickard,Microsoft,jeremyrickard,
+,,Adolfo García Veytia,Chainguard,puerco,
 Graduated,Prometheus,Augustin Husson,Amadeus,Nexucis,https://prometheus.io/governance/#team-members
 ,,Bartłomiej Płotka,Red Hat,bwplotka,
 ,,Ben Kochie,Reddit,superq,


### PR DESCRIPTION
(Part of https://github.com/kubernetes/steering/issues/256.)

- Update Kubernetes Steering members
  - Add:
    - Benjamin Elder (@BenTheElder)
    - Nabarun Pal (@palnabarun)
  - Move to non-voting:
    - Davanum Srinivas (@dims)
  - Remove:
    - Jordan Liggitt (@liggitt)
- Update Kubernetes non-voting members and affiliations

Signed-off-by: Stephen Augustus <foo@auggie.dev>

cc: @amye @caniszczyk 