### PR TITLE
Add initial Istio maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1140,3 +1140,12 @@ Sandbox,kubewarden,Flavio Castelli,SUSE,flavio,https://github.com/orgs/kubewarde
 ,,Víctor Cuadrado Juan ,SUSE,viccuad,
 ,,Raul Cabello Martin r,SUSE,raulcabello,
 ,,Rafael Fernández López ,VMware,ereslibre,
+Incubating,Istio,Craig Box,tba,craigbox,Istio transition team
+,,Francis Zhou,Google,SkyfireFrancisZ,
+,,Eric Van Norman,IBM,ericvn,
+,,John Howard,Google,howardjohn,
+,,Stewart Butler,Google,stewartbutler,
+,,David Hauck,Google,davidhauck,
+,,Louis Ryan,Google,louiscryan,
+,,Lin Sun,Solo.io,linsun,
+,,Zack Butcher,Tetrate,ZackButcher,


### PR DESCRIPTION
Add maintainers who need service desk access while we start our transition and [seek clarity on who can be listed](https://github.com/cncf/foundation/issues/433).

Signed-off-by: craigbox <craigbox@google.com>