### PR TITLE
Update Thanos project maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -396,10 +396,11 @@ Incubating,Thanos,Bartłomiej Płotka,Red Hat,bwplotka,https://github.com/thanos
 ,,Giedrius Statkevičius,Vinted,GiedriusS,
 ,,Kemal Akkoyun,Polar Signals,kakkoyun,
 ,,Lucas Servén Marín,,squat,
-,,Prem Saraswat,Red Hat,onprem,
+,,Prem Saraswat,,onprem,
 ,,Matthias Loibl,Polar Signals,metalmatze,
-,,Ben Ye,ByteDance,yeya24,
+,,Ben Ye,Amazon Web Services,yeya24,
 ,,Wiard van Rij,Roku,wiardvanrij,
+,,Matej Gera, Red Hat, matej-g,
 Incubating,Flux,Hidde Beydals,Weaveworks,hiddeco,https://github.com/fluxcd/community/blob/main/project/flux-project-maintainers.yaml
 ,,Michael Bridgen,Weaveworks,squaremo,
 ,,Stefan Prodan,Weaveworks,stefanprodan,


### PR DESCRIPTION
Signed-off-by: Matej Gera <38492574+matej-g@users.noreply.github.com>

Updating to reflect latest status (https://github.com/thanos-io/thanos/blob/main/MAINTAINERS.md).