### PR TITLE
Removing Jaime Piña from NATS Maintainer List

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -201,7 +201,6 @@ Incubating,NATS,Colin Sullivan,Synadia,ColinSullivan1,https://github.com/nats-io
 ,,Charlie Strawn,Independent,charliestrawn,
 ,,Lev Brouk,Independent,levb,
 ,,Stephen Asbury ,Independent,sasbury,
-,,Jaime Pina,Independent,variadico,
 ,,Michael Ries,Independent,mmmries,
 ,,Phil Pennock,Synadia,philpennock,
 ,,Matthias Hanel,Synadia,matthiashanel,


### PR DESCRIPTION
Jaime has resigned his seat as an official NATS maintainer.

Signed-off-by: Ginger Collison <ginger@synadia.com>