### PR TITLE
Fix formatting of § 5.d.ii

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -129,9 +129,9 @@ The CNCF shall be composed of Platinum, Gold, Silver, End User, Academic and Non
 
 	-	ii. elect a Chair of the Governing Board to preside over meetings, authorize expenditures approved by the budget and manage any day-to-day operations;
 
-			(a) The Chair of the Governing Board shall be elected to a two-year term. The Executive Director may call a special election as needed. 
+		-	a. The Chair of the Governing Board shall be elected to a two-year term. The Executive Director may call a special election as needed. 
 
-			(b) The Chair of the Governing Board shall be elected to the position and a Condorcet vote shall be run using the Condorcet-IRV method through the Cornell online service (https://civs.cs.cornell.edu/).
+		-	b. The Chair of the Governing Board shall be elected to the position and a Condorcet vote shall be run using the Condorcet-IRV method through the Cornell online service (https://civs.cs.cornell.edu/).
 
 	-	iii. vote on decisions or matters before the Governing Board;
 


### PR DESCRIPTION
This section had different formatting than the surround text.

Signed-off-by: Brian Derr <bderrly@gmail.com>