### PR TITLE
Add new maintainer to Cortex project

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -321,6 +321,7 @@ Sandbox,OpenMetrics,Ben Kochie,GitLab,superq,https://github.com/OpenObservabilit
 ,,Sumeer Bhola,Google,sumeer,
 Incubating,Cortex,Alan Protasio,Amazon Web Services,alanprot,https://github.com/cortexproject/cortex/blob/master/MAINTAINERS
 ,,Alvin Lin,Amazon Web Services,alvinlin123,
+,,Ben Ye,Amazon Web Services,yeya24,
 ,,Friedrich Gonzalez,Adobe,friedrich-at-adobe,
 Incubating,Buildpacks,Aidan Delaney,Bloomberg,aidandelaney,https://github.com/buildpacks/community/blob/main/OWNERS
 ,,Daniel Mikusa,VMware,dmikusa-pivotal,


### PR DESCRIPTION
Cortex got a new maintainer. See https://github.com/cortexproject/cortex/pull/4959

Signed-off-by: Alvin Lin <alvinlin123@gmail.com>