### PR TITLE
Update OpenTelemetry with GC election results

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -359,9 +359,9 @@ Incubating,OpenTelemetry (Governance Committee),Alolita Sharma,Amazon,alolita,ht
 ,,Bogdan Drutu,Splunk,bogdandrutu,
 ,,Daniel Dyla,Dynatrace,dyladan,
 ,,Juraci Paixão Kröhling,Grafana Labs,jpkrohling,
-,,Liz Fong-Jones,Honeycomb,lizthegrey,
 ,,Morgan James McLean,Splunk,mtwo,
 ,,Ted Young,Lightstep,tedsuo,
+,,Trask Stalnaker,Microsoft,trask,
 ,,Yuri Shkuro,Facebook,yurishkuro,
 ,OpenTelemetry (Community Maintainer),Austin Parker,Lightstep,austinlparker,https://github.com/open-telemetry/community/blob/main/community-members.md#community-management
 ,OpenTelemetry (Technical Committee excluding GC members),Armin Ruech,Dynatrace,arminru,https://github.com/open-telemetry/community/blob/master/community-members.md#technical-committee


### PR DESCRIPTION
This is a (late) update to the project maintainers based on the GC Election results.

https://opentelemetry.io/blog/2022/gc-election-results/

Related to: https://github.com/open-telemetry/community/issues/1169

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
