### PR TITLE
Fix typo of name in maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -974,7 +974,7 @@ Sandbox,Open Cluster Management,Qiu Jian,Red Hat,qiujian16,https://github.com/op
 Incubating,Dapr,Yaron Schneider,Diagrid,yaron2 ,https://github.com/dapr/community/blob/master/MAINTAINERS.md
 ,,Mark Fussell,Diagrid,msfussell,
 ,,Long Dai,Intel,daixiang0,
-,,Xavier Geernick,Tinx.AI,XavierGeerinck,
+,,Xavier Geerinck,Signalr.io,XavierGeerinck,
 ,,Rob Landers,Automattic,withinboredom,
 ,,Charlie Stanley,Robinhood,wcs1only,
 ,,Artur Souza,Microsoft,artursouza,


### PR DESCRIPTION
Signed-off-by: Xavier Geerinck <xavier.geerinck@gmail.com>

Fixing a type of my name + updating the project I am working on