### PR TITLE
Add Shubham Sharma (Maintainer Dapr)

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -985,6 +985,7 @@ Incubating,Dapr,Yaron Schneider,Diagrid,yaron2 ,https://github.com/dapr/communit
 ,,Bernd Verst,Microsoft,berndverst,
 ,,Hal Spang,Microsoft,halspang,
 ,,Abhilash Chandran,Bahag AG,abhilash-chandran,
+,,Shubham Sharma,Microsoft,shubham1172,
 Sandbox,Nocalhost,Zhenwei Wang,Tencent,jack230230,https://github.com/nocalhost/nocalhost/blob/main/MAINTAINERS.md
 ,,Wei Wang,Tencent,lyzhang1999,
 ,,Jinhao Huang,Tencent,anurnomeru,


### PR DESCRIPTION
Proposing to add Shubham Sharma whom is a very active contributor and official maintainer on Dapr

Signed-off-by: Xavier Geerinck <xavier.geerinck@gmail.com>