### PR TITLE
Add olivier vernin to Kubewarden Maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1135,6 +1135,7 @@ Sandbox,kubewarden,Flavio Castelli,SUSE,flavio,https://github.com/orgs/kubewarde
 ,,Víctor Cuadrado Juan ,SUSE,viccuad,
 ,,Raul Cabello Martin r,SUSE,raulcabello,
 ,,Rafael Fernández López ,VMware,ereslibre,
+,,Olivier Vernin,SUSE,olblak,
 Incubating,Istio,Aditya Perepa,Aviatrix,adiprerepa,https://github.com/istio/community/blob/master/org/teams.yaml
 ,,,VMWare,amjain-vmware,
 ,,Andrea Ma,IBM,andream12345,


### PR DESCRIPTION
Adding myself to the Kubewarden maintainers list 
-> https://github.com/orgs/kubewarden/teams/maintainers/members

Signed-off-by: Olivier Vernin <olivier@vernin.me>