### PR TITLE
Add Filip and Saswata as Thanos maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -389,6 +389,8 @@ Incubating,Thanos,Bartłomiej Płotka,Red Hat,bwplotka,https://github.com/thanos
 ,,Ben Ye,Amazon Web Services,yeya24,
 ,,Wiard van Rij,Roku,wiardvanrij,
 ,,Matej Gera, Red Hat, matej-g,
+,,Filip Petkovski,Shopify,fpetkovski,
+,,Saswata Mukherjee,Red Hat,saswatamcode,
 Graduated,Flux,Hidde Beydals,Weaveworks,hiddeco,https://github.com/fluxcd/community/blob/main/project/flux-project-maintainers.yaml
 ,,Michael Bridgen,Pulumi,squaremo,
 ,,Stefan Prodan,Weaveworks,stefanprodan,


### PR DESCRIPTION
Updates Thanos maintainers.

https://github.com/thanos-io/thanos/pull/5950

Signed-off-by: Saswata Mukherjee <saswataminsta@yahoo.com>