### PR TITLE
Add Tom Hadlaw to Cilium maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -847,6 +847,7 @@ Incubating,Cilium,Aditi Ghag,Isovalent,aditighag,https://github.com/cilium/ciliu
 ,,Thomas Graf,Isovalent,tgraf,
 ,,Timo Beckers,Isovalent,ti-mo,
 ,,Tobias Klauser,Isovalent,tklauser,
+,,Tom Hadlaw,Isovalent,tommyp1ckles,
 ,,Tom Payne,Isovalent,twpayne,
 ,,Vlad Ungureanu,Palantir,ungureanuvladvictor,
 ,,Weilong Cui,Google,Weil0ng,


### PR DESCRIPTION
Signed-off-by: Chris Tarazi <chris@isovalent.com>
