### PR TITLE
add zot maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1267,3 +1267,8 @@ Sandbox,OPCR,Gert Drapers,Aserto,gertd,https://github.com/opcr-io/policy/blob/ma
 Sandbox,werf,Alexey Igrychev,Palark,alexey-igrychev,https://github.com/werf/werf/blob/main/OWNERS
 ,,Timofey Kirillov,Flant,distorhead,
 ,,Ilya Lesikov,Flant,ilya-lesikov,
+Sandbox,zot,Ravi Chamarthy,Cisco,rchamarthy,https://github.com/project-zot/zot/blob/main/MAINTAINERS.md
+,,Ram Chinchani,Cisco,rchincha,
+,,Serge Hallyn,Cisco,hallyn,
+,,Andrei Aaron,Luxoft,andaaron,
+,,Tycho Andersen,Netflix,tych0,


### PR DESCRIPTION
Add zot maintainers to CNCF project maintainers list as part of onboarding zot as a sandbox project.

 Onboarding Issue: https://github.com/cncf/toc/issues/972