### PR TITLE
Re-add Josh Abreu as a Prometheus Maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -27,6 +27,7 @@ Graduated,Prometheus,Augustin Husson,Amadeus,Nexucis,https://prometheus.io/gover
 ,,Ganesh Vernekar,Grafana Labs,codesome,
 ,,Goutham Veeramachaneni,Grafana Labs,gouthamve,
 ,,Johannes Ziemke,Independent,discordianfish,
+,,Josh Abreu,Grafana Labs,gotjosh,
 ,,Julien Pivotto,Inuits,roidelapluie,
 ,,Julius Volz,Promlabs,juliusv,
 ,,Kemal Akkoyun,Polar Signals,kakkoyun,


### PR DESCRIPTION
It seems that https://github.com/cncf/foundation/commit/ef8a83011c896f69e6c1ec2a5be3f62e77aabf36 removed my name from the list of Project Maintainers. Let's re-add so that I can submit our maintainer talk :)

Signed-off-by: gotjosh <josue.abreu@gmail.com>