### PR TITLE
Add DevSpace maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1277,3 +1277,6 @@ Sandbox,zot,Ravi Chamarthy,Cisco,rchamarthy,https://github.com/project-zot/zot/b
 ,,Serge Hallyn,Cisco,hallyn,
 ,,Andrei Aaron,Luxoft,andaaron,
 ,,Tycho Andersen,Netflix,tych0,
+Sandbox,DevSpace,Fabian Kramm,Loft Labs,FabianKramm,https://github.com/devspace-sh/devspace/blob/main/MAINTAINERS.md
+,,Lukas Gentele,Loft Labs,LukasGentele,
+,,Russell Centanni,Loft Labs,lizardruss,


### PR DESCRIPTION
Signed-off-by: Fabian Kramm <fab.kramm@googlemail.com>