### PR TITLE
Adding @puerco to Knative Projects maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1042,7 +1042,7 @@ Sandbox,Devfile,Andreas Resios,AWS,resios, https://github.com/devfile/api/blob/m
 ,,Tomas Kral,Red Hat,kadel,
 Incubating,Knative,Carlos Santana,AWS,csantanapr, https://github.com/knative/community/blob/main/OWNERS_ALIASES
 ,,Lance Ball,Red Hat,lance,
-,,Murugappan Chetty,Optum,itsmurugappan,
+,,Adolfo García Veytia,Chainguard,puerco,
 ,,Naina Singh,Red Hat,nainaz,
 ,,Mauricio Salatino,Diagrid,salaboy,
 ,,Dave Protasowski,VMware,dprotaso,


### PR DESCRIPTION
This PR also removes @itsmurugappan from the maintainers list
Signed-off-by: salaboy <Salaboy@gmail.com>