### PR TITLE
Update Kyverno active maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -757,9 +757,6 @@ Incubating,Kyverno,Jim Bugwadia,Nirmata,JimBugwadia,https://github.com/kyverno/k
 ,,Chip Zoller,Nirmata,chipzoller,
 ,,Marcel Muller,Giant Swarm GmbH,MarcelMue,
 ,,Trey Dockendorf,treydock,Ohio Supercomputer Center,
-,,Vyankatesh Kudtarkar,Nirmata,vyankyGH,
-,,Prateek Pandey,Nirmata,prateekpandey14,
-,,Sambhav Kothari,Bloomberg,samj1912,
 ,,Frank Jogeleit,Lovoo GmbH,fjogeleit ,
 Sandbox,OpenGitOps,Chris Patterson,GitHub,chrispat,https://github.com/open-gitops/project/blob/main/MAINTAINERS
 ,,Chris Sanders,Microsoft,csand-msft,

--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -754,7 +754,7 @@ Sandbox,Pravega,Flavio Junqueira,Pravega,fpj,https://github.com/pravega/.github/
 ,,Raul Gracia,Dell,RaulGracia,
 Incubating,Kyverno,Jim Bugwadia,Nirmata,JimBugwadia,https://github.com/kyverno/kyverno/blob/main/MAINTAINERS.md
 ,,Shuting Zhao,Nirmata,realshuting,
-,,Chip Zoller,Dell Technologies,chipzoller,
+,,Chip Zoller,Nirmata,chipzoller,
 ,,Marcel Muller,Giant Swarm GmbH,MarcelMue,
 ,,Trey Dockendorf,treydock,Ohio Supercomputer Center,
 ,,Vyankatesh Kudtarkar,Nirmata,vyankyGH,


### PR DESCRIPTION
This PR updates the CSV to be consistent with the current [Kyverno maintainers list](https://github.com/kyverno/kyverno/blob/main/MAINTAINERS.md).