### PR TITLE
Update `fr.md` to remove unrequired mention

### DIFF
--- a/code-of-conduct-languages/fr.md
+++ b/code-of-conduct-languages/fr.md
@@ -1,8 +1,5 @@
 Ce texte est également disponible à l'adresse suivante: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
 
-À TRADUIRE :
-------------
-
 Code de conduite de la communauté de la CNCF v1.0
 -------------------------------------------------
 


### PR DESCRIPTION
This Pull Request updates `fr.md` to remove an unrequired mention of `À TRADUIRE` (meaning `to translate`). The entire text being translated from english to french, there is no more need to translate it.