### PR TITLE
Add Bengali to other languages available list in code-of-conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -2,6 +2,7 @@
 
 Other languages available:
 - [Arabic/العربية](code-of-conduct-languages/ar.md)
+- [Bengali/বাংলা](code-of-conduct-languages/bn.md)
 - [Bulgarian/Български](code-of-conduct-languages/bg.md)
 - [Chinese/中文](code-of-conduct-languages/zh.md)
 - [Czech/Česky](code-of-conduct-languages/cs.md)


### PR DESCRIPTION
Bengali language added to the list of 'other languages available' in code-of-conduct.

related issue: #551 