### PR TITLE
Add new Akri maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -969,6 +969,9 @@ Sandbox,Akri,Kate Goldenring,Fermyon,kate-goldenring,https://github.com/project-
 ,,Jiri Appl,Microsoft,jiria,
 ,,Edrick Wong,Amazon,edrickwong,
 ,,Adithya Jayachandran,Microsoft,adithyaj,
+,,Nicolas Belouin,SUSE,diconico07,
+,,Johnson Shih,Microsoft,johnsonshih,
+,,Yu Jin Kim,Microsoft,yujinkim-msft,
 Sandbox,MetalLB,Rodrigo Campos,Microsoft,rata,https://github.com/metallb/metallb/blob/main/CODEOWNERS
 ,,Johannes Liebermann,Microsoft,johananl,
 ,,Russell Bryant,Red Hat,russellb,


### PR DESCRIPTION
We've added @diconico07 @johnsonshih and @yujinkim-msft as maintainers.

@yujinkim-msft is not a part of our codeowners but is essential to maintaining the Akri community, running [community meetings](https://hackmd.io/UUqW3_GgQDimQ5b23rS9rg), setting up and staffing our project pavilion booth at KubeCons, and maintaining Slack engagement.