### PR TITLE
Update KubeVela maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -924,12 +924,16 @@ Sandbox,Service Mesh Performance,Lee Calcote,Layer5,leecalcote,https://github.co
 ,,Utkarsh Srivastava,Layer5,utkarsh-pro,
 ,,Abishek Kumar,Layer5,kumarabd,
 ,,Navendu Pottekkat,Layer5,navendu-pottekkat,
-Sandbox,KubeVela,Jianbo Sun,Alibaba,wonderflow,https://github.com/kubevela/community/blob/main/OWNERS.md
+Incubating,KubeVela,Jianbo Sun,Alibaba,wonderflow,https://github.com/kubevela/community/blob/main/OWNERS.md
 ,,Zheng Xi Zhou,Independent,zzxwill,
 ,,guoxudong,GitLab,sunny0826 ,
 ,,Qingguo Zeng,Alibaba,barnettZQG,
 ,,Da Yin,Alibaba,Somefive,
 ,,Jiahang Xu,China Merchants Bank,jefree-cat,
+,,Daniel Higuero,Napptive,dhiguero
+,,Anoop Gopalakrishnan,Guidewire,anoop2811
+,,Fog Dong,BentoML,FogDong
+,,Lei Zhang,JD.com,StevenLeiZhang
 Sandbox,Serverless Devs,Anycodes,National University of Defense Technology,anycodes,https://github.com/Serverless-Devs/Serverless-Devs/blob/master/OWNERS
 ,,Kun Yuan,Alibaba Cloud,heimanba,
 ,,Shoushuai Wang,Boyan,wss-git,


### PR DESCRIPTION
This PR updates the list of KubeVela maintainers, and changes the state of the project to Incubating. The current maintainer list can be found for reference in the [KubeVela community repo](https://github.com/kubevela/community/blob/main/OWNERS.md).