### PR TITLE
Revert "Update longhorn maintainers"

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -443,9 +443,8 @@ Incubating,KubeVirt,David Vossel,Red Hat,davidvossel,https://github.com/kubevirt
 ,,Andrew Burden,Red Hat,aburdenthehand,
 Incubating,Longhorn,Sheng Yang,SUSE,yasker,https://github.com/longhorn/longhorn/blob/master/MAINTAINERS
 ,,Shuo Wu,SUSE,shuo-wu,
+,,Joshua Moody,SUSE,joshimoo,
 ,,David Ko,SUSE,innobead,
-,,Derek Su,SUSE,derekbit,
-,,Phan Le,SUSE,PhanLe1010,
 Incubating,CubeFS,Haifeng Liu ,OPPO,bladehliu,https://github.com/cubefs/cubefs/blob/master/MAINTAINERS.md
 ,,Xiaochun HE,OPPO,xiaochunhe,
 ,,Hongyan Wang,OPPO,jadewang198510,


### PR DESCRIPTION
Reverts cncf/foundation#590
https://github.com/longhorn/longhorn/blob/master/MAINTAINERS does not match and they should. 