### PR TITLE
Add link to `hi` code-of-conduct on `en` version

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -8,6 +8,7 @@ Other languages available:
 - [Farsi/فارسی](code-of-conduct-languages/fa.md)
 - [French/Français](code-of-conduct-languages/fr.md)
 - [German/Deutsch](code-of-conduct-languages/de.md)
+- [Hindi/हिन्दी](code-of-conduct-languages/hi.md)
 - [Indonesian/Bahasa Indonesia](code-of-conduct-languages/id.md)
 - [Italian/Italiano](code-of-conduct-languages/it.md)
 - [Japanese/日本語](code-of-conduct-languages/jp.md)


### PR DESCRIPTION
fixes #602 

The link to Hindi code of conduct is not present on the English version unlike other localizations. This PR fixes it :)