### PR TITLE
Add Byron Ruth to maintainers list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -213,6 +213,7 @@ Incubating,NATS,Colin Sullivan,Luxant Solutions,ColinSullivan1,https://github.co
 ,,Scott Fauerbach,Synadia,scottf,
 ,,Tomasz Pietrek, Synadia,jarema,
 ,,Neil Twigg, Synadia, neilalexander,
+,,Byron Ruth, Synadia, bruth,
 Graduated,Linkerd,Oliver Gould,Buoyant,olix0r,https://github.com/linkerd/linkerd2/blob/main/MAINTAINERS.md
 ,,Alex Leong ,Buoyant,adleong,
 ,,Zarahi Dichev,Buoyant,zaharidichev,


### PR DESCRIPTION
Byron Ruth voted in as a NATS maintainer by a majority vote of NATS maintainers [https://github.com/nats-io/nats-general/issues/90](url)