### PR TITLE
docs: add maintainers file to Eraser entry

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1391,7 +1391,7 @@ Sandbox,SOPS,Hidde Beydals,Weaveworks,hiddeco,https://github.com/getsops/communi
 ,,Andrew Block,Red Hat,sabre1041,
 ,,Devin Buhl,Individual,onedr0p,
 ,,Devin Stein,Individual,devstein,
-Sandbox,Eraser,Sertac Ozercan,Microsoft,sozercan,
+Sandbox,Eraser,Sertac Ozercan,Microsoft,sozercan,https://github.com/eraser-dev/eraser/blob/main/MAINTAINERS.md
 ,,Ashna Mehrotra,Microsoft,ashnamehrotra,
 ,,Peter Engelbert,Microsoft,pmengelbert,
 ,,Brian Goff,Microsoft,cpuguy83,


### PR DESCRIPTION
When we added Eraser as a Sandbox project, we missed the maintainers file. Adding it now.