### PR TITLE
fixing typo 'socioeconomic' in code-of-conduct.md

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -28,7 +28,7 @@ an open and welcoming community, we pledge to respect all people who participate
 through reporting issues, posting feature requests, updating documentation,
 submitting pull requests or patches, attending conferences or events, or engaging in other community or project activities.
 
-We are committed to making participation in the CNCF community a harassment-free experience for everyone, regardless of age, body size, caste, disability, ethnicity, level of experience, family status, gender, gender identity and expression, marital status, military or veteran status, nationality, personal appearance, race, religion, sexual orientation, socieconomic status, tribe, or any other dimension of diversity.
+We are committed to making participation in the CNCF community a harassment-free experience for everyone, regardless of age, body size, caste, disability, ethnicity, level of experience, family status, gender, gender identity and expression, marital status, military or veteran status, nationality, personal appearance, race, religion, sexual orientation, socioeconomic status, tribe, or any other dimension of diversity.
 
 ## Scope 
 


### PR DESCRIPTION
![image](https://github.com/cncf/foundation/assets/65087356/87f434d3-a6a4-4615-ba48-ad30808301d4)
