### PR TITLE
maintainers: Update Confidential Containers maintainers list & governance members URL

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1096,9 +1096,12 @@ Sandbox,Confidential Containers,Ariel Adam,Red Hat,ariel-adam,https://github.com
 ,,Larry Dewey,AMD,larrydewey,
 ,,Tobin Feldman-Fitzthum,IBM,fitzthum,
 ,,James Magowan,IBM,magowan,
-,,Dan Middleton,Intel,dcmiddle,
+,,Fabiano Fidêncio,Intel,fidencio,
 ,,Peter Zhu,Intel,peterzcst,
 ,,Samuel Ortiz,Rivos,sameo,
+,,Ananya Garg,Microsoft,angarg05,
+..Vicent Batts,Microsoft,vbatts,
+,,Zvonko Kaisere,NVIDIA,zvonkok,
 Sandbox,Teller,Dotan Nahum,Check Point,jondot,https://github.com/SpectralOps/teller/blob/master/MAINTAINERS.md
 ,,Elad Kaplan,Check Point,kaplanelad,
 ,,Lior Reuven,Check Point,lreuven,

--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1089,7 +1089,7 @@ Sandbox,OpenFunction,Benjamin Huo,QingCloud,benjaminhuo,https://github.com/OpenF
 ,,Lize Cai,SAP,lizzzcai,
 ,,Dehao Cheng,QingCloud,wenchajun,
 ,,Shanyou Zhang,Weyhd,geffzhang,
-Sandbox,Confidential Containers,Ariel Adam,Red Hat,ariel-adam,https://github.com/confidential-containers/community/blob/main/MAINTAINERS
+Sandbox,Confidential Containers,Ariel Adam,Red Hat,ariel-adam,https://github.com/confidential-containers/confidential-containers/blob/main/governance.md#members
 ,,Pradipta Banerjee,Red Hat,bpradipt,
 ,,Zhang Jia,Alibaba,jiazhang0,
 ,,Jiang Liu,Alibaba,jiangliu,


### PR DESCRIPTION
---

 maintainers: Update Confidential Containers maintainers

 Three new members have joined the Confidential Containers Steering
 Committee (Ananya Garg and Vicent Batts, from Microsoft; Zvonko Kaiser,
 from NVIDIA), and Intel has updated its representation (with Fabiano
 Fidêncio replacing Dan Middleton).

---

project-maintainers: Update Confidential Containers URL

We've merged two repos into one, and now the list of the maintainers is
part of the governance file, which is now updated.

---