### PR TITLE
project_maintainers: Update Kubernetes memberships

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -20,6 +20,7 @@ Graduated,Kubernetes,Bob Killen,Google,mrbobbytables,https://git.k8s.io/steering
 ,,Jeremy Rickard,Microsoft,jeremyrickard,
 ,,Adolfo García Veytia,Chainguard,puerco,
 ,,Carlos Tadeu Panato Jr.,Chainguard,cpanato,
+,,Verónica López,PlanetScale,Verolop,
 Graduated,Prometheus,Augustin Husson,Amadeus,Nexucis,https://prometheus.io/governance/#team-members
 ,,Bartłomiej Płotka,Google,bwplotka,
 ,,Ben Kochie,Reddit,superq,

--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1,12 +1,13 @@
 ﻿,Project,Maintainer Name,Company,Github Name,OWNERS/MAINTAINERS
-Graduated,Kubernetes,Christoph Blecker,Red Hat,cblecker,https://git.k8s.io/steering#members
-,,Carlos Tadeu Panato Jr.,Chainguard,cpanato,
-,,Bob Killen,Google,mrbobbytables,
+Graduated,Kubernetes,Bob Killen,Google,mrbobbytables,https://git.k8s.io/steering#members
 ,,Stephen Augustus,Cisco,justaugustus,
-,,Tim Pepper,VMware,tpepper,
 ,,Benjamin Elder,Google,BenTheElder,
 ,,Nabarun Pal,VMware,palnabarun,
+,,Maciej Szulik,Red Hat,soltysh,
+,,Paco Xu 徐俊杰,DaoCloud,pacoxu,
+,,Patrick Ohly,Intel,pohly,
 ,Kubernetes: SIG Contributor Experience (non-voting),Josh Berkus,Red Hat,jberkus,https://git.k8s.io/community/sig-contributor-experience#leadership
+,,Christoph Blecker,Red Hat,cblecker,
 ,,Kaslin Fields,Google,kaslin,
 ,,Madhav Jivrajani,VMware,MadhavJivrajani,
 ,,Nikhita Raghunath,VMware,nikhita,
@@ -18,6 +19,7 @@ Graduated,Kubernetes,Christoph Blecker,Red Hat,cblecker,https://git.k8s.io/steer
 ,Kubernetes: SIG Release (non-voting),Sascha Grunert,Red Hat,saschagrunert,https://git.k8s.io/community/sig-release#leadership
 ,,Jeremy Rickard,Microsoft,jeremyrickard,
 ,,Adolfo García Veytia,Chainguard,puerco,
+,,Carlos Tadeu Panato Jr.,Chainguard,cpanato,
 Graduated,Prometheus,Augustin Husson,Amadeus,Nexucis,https://prometheus.io/governance/#team-members
 ,,Bartłomiej Płotka,Google,bwplotka,
 ,,Ben Kochie,Reddit,superq,


### PR DESCRIPTION
- Update Kubernetes Steering members for 2023 election
  - Add:
    - Maciej Szulik - @soltysh
    - Paco Xu 徐俊杰 - @pacoxu
    - Patrick Ohly - @pohly
  - Emeritus Steering:
    - Carlos Tadeu Panato Jr. - @cpanato (remains on the list as a SIG Release Technical Lead)
    - Christoph Blecker - @cblecker (remains on the list as a SIG Contributor Experience Technical Lead)
    - Tim Pepper - @tpepper
- Add Verónica López (@Verolop) to SIG Release leads

Thanks to all of the Emeritus members for your service and welcome to the new Kubernetes Steering Committee members!

Signed-off-by: Stephen Augustus <foo@auggie.dev>

cc: @amye @caniszczyk @mrbobbytables @BenTheElder @palnabarun 
xref: https://github.com/kubernetes/steering/issues/273