### PR TITLE
Add Piotr Piotrowski to NATS Maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -219,6 +219,7 @@ Incubating,NATS,Colin Sullivan,Luxant Solutions,ColinSullivan1,https://github.co
 ,,Tomasz Pietrek, Synadia,jarema,
 ,,Neil Twigg, Synadia, neilalexander,
 ,,Byron Ruth, Synadia, bruth,
+,,Piotr Piotrowski, Synadia, piotrpio,
 Graduated,Linkerd,Oliver Gould,Buoyant,olix0r,https://github.com/linkerd/linkerd2/blob/main/MAINTAINERS.md
 ,,Alex Leong ,Buoyant,adleong,
 ,,Zarahi Dichev,Buoyant,zaharidichev,


### PR DESCRIPTION
Adding Piotr Piotrowski to NATS maintainers via majority vote [Issue #93]( https://github.com/nats-io/nats-general/issues/93)