### PR TITLE
Tweak and improve code of conduct documentation

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -30,7 +30,7 @@ submitting pull requests or patches, attending conferences or events, or engagin
 
 We are committed to making participation in the CNCF community a harassment-free experience for everyone, regardless of age, body size, caste, disability, ethnicity, level of experience, family status, gender, gender identity and expression, marital status, military or veteran status, nationality, personal appearance, race, religion, sexual orientation, socioeconomic status, tribe, or any other dimension of diversity.
 
-## Scope 
+## Scope
 
 This code of conduct applies:
 * within project and community spaces,
@@ -54,7 +54,7 @@ Examples of behavior that contributes to a positive environment include but are 
 * Focusing on what is best not just for us as individuals, but for the
   overall community
 * Using welcoming and inclusive language
-  
+
 
 Examples of unacceptable behavior include but are not limited to:
 
@@ -69,27 +69,27 @@ Examples of unacceptable behavior include but are not limited to:
 * Unwelcome sexual or romantic attention or advances
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
-  
+
 The following behaviors are also prohibited:
 * Providing knowingly false or misleading information in connection with a Code of Conduct investigation or otherwise intentionally tampering with an investigation.
 * Retaliating against a person because they reported an incident or provided information about an incident as a witness.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. 
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct.
 By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect
-of managing a CNCF project. 
+of managing a CNCF project.
 Project maintainers who do not follow or enforce the Code of Conduct may be temporarily or permanently removed from the project team.
 
-## Reporting 
+## Reporting
 
 For incidents occurring in the Kubernetes community, contact the [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) via <conduct@kubernetes.io>. You can expect a response within three business days.
 
-For other projects, or for incidents that are project-agnostic or impact multiple CNCF projects, please contact the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/) via conduct@cncf.io.  Alternatively, you can contact any of the individual members of the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/) to submit your report. For more detailed instructions on how to submit a report, including how to submit a report anonymously, please see our [Incident Resolution Procedures](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md). You can expect a response within three business days.
+For other projects, or for incidents that are project-agnostic or impact multiple CNCF projects, please contact the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/) via <conduct@cncf.io>.  Alternatively, you can contact any of the individual members of the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/) to submit your report. For more detailed instructions on how to submit a report, including how to submit a report anonymously, please see our [Incident Resolution Procedures](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md). You can expect a response within three business days.
 
-For incidents ocurring at CNCF event that is produced by the Linux Foundation, please contact eventconduct@cncf.io.
+For incidents occurring at CNCF event that is produced by the Linux Foundation, please contact <eventconduct@cncf.io>.
 
-## Enforcement 
+## Enforcement
 
-Upon review and investigation of a reported incident, the CoC response team that has jurisdiction will determine what action is appropriate based on this Code of Conduct and its related documentation. 
+Upon review and investigation of a reported incident, the CoC response team that has jurisdiction will determine what action is appropriate based on this Code of Conduct and its related documentation.
 
 For information about which Code of Conduct incidents are handled by project leadership, which incidents are handled by the CNCF Code of Conduct Committee, and which incidents are handled by the Linux Foundation (including its events team), see our [Jurisdiction Policy](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md).
 


### PR DESCRIPTION
## Changes

1. Fix typos for `occcuring` words
2. There are tones of unnecessary trailing spaces in the file, removed them
3. Use unified link for email addresses