### PR TITLE
feat: update project maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1134,7 +1134,10 @@ Sandbox,OpenCost,Ajay Tripathy,Kubecost,AjayTripathy,https://github.com/kubecost
 Sandbox,External Secrets Operator,Moritz Johner,Form3,moolen,https://github.com/external-secrets/external-secrets/blob/main/.github/PAUL.yaml
 ,,Lucas Severo Alves,Red Hat,knelasevero,
 ,,Gustavo Fernandes de Carvalho,Container Solutions,gusfcarvalho,
-,,Sebastian Gomez,Container Solutions,sebagomez,
+,,Sebastian Gomez,Ubisoft,sebagomez,
+,,Shuhei Kitagawa,Mercari,shuheiktgw,
+,,Gergely Brautigam,Weaveworks,skarlso,
+,,Idan Adar,IBM,IdanAdar,
 Sandbox,ko,Jason Hall,Chainguard,imjasonh,https://github.com/ko-build/ko/blob/main/MAINTAINERS.md
 ,,Jon Johnson,Google,jonjohnsonjr,
 ,,Matt Moore,Chainguard,mattmoor,


### PR DESCRIPTION
This PR updates the maintainers list of external-secrets. Going to update via [cncf-maintainer-changes@cncf.io](mailto:cncf-maintainer-changes@cncf.io) as well as described in the readme.