### PR TITLE
Add SIG etcd leadership roles

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -260,12 +260,13 @@ Graduated,Harbor,Daniel Jiang,VMware,reasonerjt,https://github.com/goharbor/comm
 ,,Vadim Bauer,8gears,Vad1mo,
 ,Harbor: SIG Community,Orlin Vasilev,VMware,OrlinVasilev,
 ,Harbor: SIG Docs,Abigail McCarthy,VMware,a-mccarthy,
-Graduated,etcd,Benjamin Wang,VMware,ahrtr,https://github.com/etcd-io/etcd/blob/main/MAINTAINERS
+Graduated,etcd,Benjamin Wang,VMware,ahrtr,https://github.com/etcd-io/etcd/blob/main/OWNERS
 ,,Hitoshi Mitake,,mitake,
 ,,Marek Siarkowicz,Google,serathius,
 ,,Piotr Tabor,Google,ptabor,
 ,,Sahdev Zala,IBM,spzala,
 ,,Wenjia Zhang,Google,wenjiaswe,
+,SIG etcd,James Blair,Red Hat,jmhbnz,https://github.com/kubernetes/community/tree/master/sig-etcd#leadership
 Graduated,Open Policy Agent,Tim Hinrichs,Styra,timothyhinrichs,https://github.com/open-policy-agent/opa/blob/master/MAINTAINERS.md
 ,,Torin Sandall,Styra,tsandall,
 ,,Ashutosh Narkar,Styra,ashutosh-narkar,


### PR DESCRIPTION
Recently SIG etcd was established, with two tech leads and chair roles.

As discussed and agreed through maintainer majority in https://github.com/etcd-io/etcd/pull/16794#issuecomment-1783987851 this pull request:
1. Renames the etcd project maintainers source of truth to our newly added `OWNERS` file.
2. Adds a separate section under etcd for SIG etcd leadership roles .

cc @serathius, @ahrtr, @wenjiaswe, @jberkus


