### PR TITLE
Pick correct PackageName for Vault API exception

### DIFF
--- a/license-exceptions/cncf-exceptions-2023-06-27.spdx
+++ b/license-exceptions/cncf-exceptions-2023-06-27.spdx
@@ -64,7 +64,7 @@ PackageComment: not auto-allowlist because: Non-allowlist license(s); approved b
 
 ##### Package: hashicorp/vault
 
-PackageName: hashicorp/vault
+PackageName: hashicorp/vault/api
 SPDXID: SPDXRef-Package7
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false


### PR DESCRIPTION
Notes:
- Vault itself is BSL - https://github.com/hashicorp/vault/blob/main/LICENSE
- Vault API is MPL 2.0 - https://github.com/hashicorp/vault/blob/main/api/LICENSE
- Scanning https://github.com/cncf/foundation/issues/617 the exception requested was for *Vault API* (not Vault itself)

So the question to @amye and other GB members, is it right that there is a typo in this text and exception was granted to the MPL'ed Vault API, right? If so, please merge this PR.