### PR TITLE
Update project-maintainers.csv for crossplane

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -612,9 +612,9 @@ Sandbox,BFE,Miao Zhang,Baidu,mileszhang2016,https://github.com/bfenetworks/bfe/b
 Incubating,Crossplane,Bassam Tabbara,Upbound,bassam,https://github.com/crossplane/crossplane/blob/master/OWNERS.md
 ,,Nic Cope,Upbound,negz,
 ,,Jared Watts,Upbound,jbw976,
-,,Daniel Mangum,Upbound,hasheddan,
-,,Muvaffak Onus,Upbound,muvaf,
 ,,Hasan Turken,Upbound,turkenh,
+,,Philippe Scorsolini,Upbound,pisco,
+,,Bob Haddleton,Nokia,bobh66,
 Incubating,Contour,Steve Kriss,VMware,skriss,https://github.com/projectcontour/community/blob/master/MAINTAINERS.md
 ,,Steve Sloka,VMware,stevesloka,
 ,,Alex Xu,VMware,xaleeks,


### PR DESCRIPTION
This brings project-maintainers.csv in line with
https://github.com/crossplane/crossplane/blob/master/OWNERS.md
