### PR TITLE
Add Cecil Phillip, remove Nyemade Uverski

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1027,7 +1027,7 @@ Incubating,Dapr,Yaron Schneider,Diagrid,yaron2 ,https://github.com/dapr/communit
 ,,Alessandro Segala,Microsoft,ItalyPaleAle,
 ,,Ryan Nowak, Microsoft,rynowak,
 ,,Marc Duiker,Diagrid,marcduiker,
-,,Nyemade Uverski,Microsoft,nyemade-uversky,
+,,Cecil Phillip,Stripe,cecilphillip,
 Sandbox,Nocalhost,Zhenwei Wang,Tencent,jack230230,https://github.com/nocalhost/nocalhost/blob/main/MAINTAINERS.md
 ,,Wei Wang,Tencent,lyzhang1999,
 ,,Jinhao Huang,Tencent,anurnomeru,


### PR DESCRIPTION
Cecil is a new community manager for Dapr. Nyemade has left the project. 

See https://github.com/dapr/community/issues/430