### PR TITLE
Add troy0820 to list of maintainers for porter

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -719,6 +719,7 @@ Sandbox,Porter,Sarah Christoff,Microsoft,hypernovasunnix,https://github.com/getp
 ,,Yingrong Zhao,Honeycomb,vinozzz,
 ,,Brian DeGeeter,F5,bdegeeter,
 ,,Steven Gettys,F5,sgettys,
+,,Troy Connor,Microsoft,troy0820
 Sandbox,OpenYurt,Chao Zheng,Alibaba,charleszheng44,https://github.com/alibaba/openyurt/blob/master/OWNERS
 ,,Fei Guo,Alibaba,Fei-Guo,
 ,,frank-huangyuqi,Alibaba,huangyuqi,


### PR DESCRIPTION
Add Troy Connor to list of maintainers of `getporter/porter` as per https://github.com/orgs/getporter/teams/maintainers