### PR TITLE
Update Karmada project level to incubating

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -995,7 +995,7 @@ Sandbox,SuperEdge,Gerald Wang,Tencent,neweyes,https://github.com/superedge/super
 ,,Yiwei Chen,Tencent,yiwei-C,
 ,,Wenhu Wang,ZTO,wenhuwang,
 ,,Roy Liang,Tencent,lianghao208,
-Sandbox,Karmada,Kevin Wang,Huawei,kevin-wangzefeng,https://github.com/karmada-io/karmada/blob/master/MAINTAINERS.md
+Incubating,Karmada,Kevin Wang,Huawei,kevin-wangzefeng,https://github.com/karmada-io/karmada/blob/master/MAINTAINERS.md
 ,,Hanbo Li,Huawei,mrlihanbo,
 ,,Hongcai Ren,Huawei,RainbowMango,
 ,,Lei Xue,Tencent,carmark,


### PR DESCRIPTION
The CNCF TOC has voted to accept Karmada as a CNCF incubating project, see the public news here:
https://www.cncf.io/blog/2023/12/12/karmada-brings-kubernetes-multi-cloud-capabilities-to-cncf-incubator/

This PR updates the project levels from `Sandbox` to `Incubating`.