### PR TITLE
AddKnative  WG leads to maintainers list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1077,6 +1077,17 @@ Incubating,Knative,Ali Ok,Red Hat,aliok, https://github.com/knative/community/bl
 ,,Paul Schweigert,IBM,psschwei,
 ,,Krsna Mahapatra,Broadcom,krsna-m,
 ,,David Hadas,IBM,davidhadas,
+,,Vincent Hou,Bloomberg,houshengbo,
+,,Luke Kingland,Red Hat,lkingland,
+,,Navid Shaikh,Broadcom,navidshaikh,
+,,Roland Huss,Red Hat,rhuss,
+,,Samia Nneji,Broadcom,snneji,
+,,Pierangelo Di Pilato,Red Hat,pierDipi,
+,,Mahamed Ali,Cisco,upodroid,
+,,Calum Murray,Red Hat,cali0707,
+,,Leo Li,Red Hat,leo6leo,
+,,Mariana Mejia,OCAD University,mmejia02,
+,,Zainab Husain,OCAD University,zainabhusain227,
 Sandbox,FabEdge,Haotao Geng,BoCloud,haotaogeng,https://github.com/FabEdge/fabedge/blob/main/MAINTAINERS.md
 ,,Jianbo Yan,BoCloud,yanjianbo1983,
 Sandbox,sealer,Haitao Fang,Alibaba Group,fanux,https://github.com/alibaba/sealer/blob/main/MAINTAINERS.md


### PR DESCRIPTION
As we decided in Knative community, we want to have the WG leads in the maintainers list: https://github.com/knative/community/issues/1383#issuecomment-1865809475

Added missing people from the list https://github.com/knative/community/blob/main/peribolos/knative-OWNERS_ALIASES

cc @puerco @salaboy @nainaz @evankanderson 