### PR TITLE
feat: update kyverno active maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -772,10 +772,13 @@ Sandbox,Pravega,Flavio Junqueira,Pravega,fpj,https://github.com/pravega/.github/
 ,,Raul Gracia,Dell,RaulGracia,
 Incubating,Kyverno,Jim Bugwadia,Nirmata,JimBugwadia,https://github.com/kyverno/kyverno/blob/main/MAINTAINERS.md
 ,,Shuting Zhao,Nirmata,realshuting,
-,,Chip Zoller,Nirmata,chipzoller,
+,,Chip Zoller,Stackwatch,chipzoller,
 ,,Marcel Muller,Giant Swarm GmbH,MarcelMue,
 ,,Trey Dockendorf,treydock,Ohio Supercomputer Center,
-,,Frank Jogeleit,Lovoo GmbH,fjogeleit ,
+,,Frank Jogeleit,Lovoo GmbH,fjogeleit,
+,,Charles-Edouard Brétéché,Nirmata,eddycharly,
+,,Vishal Choudhary,Nirmata,vishal-chdhry,
+,,Mariam Fahmy,Nirmata,MariamFahmy98,
 Sandbox,OpenGitOps,Chris Patterson,GitHub,chrispat,https://github.com/open-gitops/project/blob/main/MAINTAINERS
 ,,Chris Sanders,Microsoft,csand-msft,
 ,,Dan Garfield,CodeFresh,todaywasawesome,


### PR DESCRIPTION
This PR updates the CSV to be consistent with the current [Kyverno maintainers list](https://github.com/kyverno/kyverno/blob/main/MAINTAINERS.md).