### PR TITLE
Updating code of conduct Czech translation

### DIFF
--- a/code-of-conduct-languages/cs.md
+++ b/code-of-conduct-languages/cs.md
@@ -1,29 +1,71 @@
-Kodex chování komunity CNCF v1.0
----------------------------------------
 
-### Kodex chování pro přispěvatele
+## Kodex chování komunity
 
-Jako přispěvatelé a udržovatelé tohoto projektu se v zájmu podpory otevřené a přívětivé komunity zavazujeme respektovat všechny lidi, kteří přispívají prostřednictvím hlášení problémů, zveřejňováním žádostí o funkce, aktualizací dokumentace, předkládáním žádostí o stažení nebo oprav a dalších aktivit.
+Jako přispěvatelé, správci a účastníci komunity CNCF se v zájmu podpory otevřené a laskavé komunity zavazujeme respektovat všechny lidi, kteří se účastní nebo přispívají hlášením problémů, odesíláním žádostí o funkce, aktualizací dokumentace, odesíláním návrhů na sloučení sady změn nebo záplat, účastí na konferencích nebo akcích nebo zapojením do jiných aktivit komunity nebo projektu.
 
-Zavázali jsme se, že z účasti na tomto projektu uděláme zážitek bez obtěžování pro každého, bez ohledu na úroveň zkušeností, pohlaví, genderovou identitu a vyjádření, sexuální orientaci, zdravotní postižení, osobní vzhled, velikost těla, rasu, etnický původ, věk, náboženství nebo státní příslušnost.
+Jsme zavázáni k tomu, aby účast všech lidí v komunitě CNCF probíhala bez jakéhokoli druhu obtěžování, bez ohledu na věk, velikost, kastu, hendikep, etnickou příslušnost, úroveň zkušeností, rodinný stav, pohlaví, genderovou identitu nebo vyjádření, manželský stav, vojenský status nebo status veterána, národnost, vzhled, rasu, náboženství, sexuální orientaci, socioekonomický status, kmenovou příslušnost nebo jakýkoli jiný rozměr diverzity.
 
-Mezi příklady nepřijatelného chování účastníků patří:
+## Rozsah
 
-- Používání sexualizovaného jazyka nebo obrazů
-- Osobní útoky
-- Trollování nebo urážlivé / hanlivé komentáře
-- Veřejné nebo soukromé obtěžování
-- Zveřejňování soukromých informací jiných osob, jako jsou fyzické nebo elektronické adresy, bez výslovného souhlasu
-- Jiné neetické nebo neprofesionální chování
+Tento kodex chování platí:
 
-Správci projektů mají právo a odpovědnost odstraňovat, upravovat nebo odmítat komentáře, závazky, kód, úpravy wiki, problémy a další příspěvky, které nejsou v souladu s tímto Kodexem chování. Přijetím tohoto kodexu chování se správci projektů zavazují k spravedlivému a důslednému uplatňování těchto zásad na všechny aspekty řízení tohoto projektu. Správci projektů, kteří nedodržují nebo nevynucují Kodex chování, mohou být z projektového týmu trvale odstraněni.
+* v prostorech rozsahu projektu a komunity,
+* v dalších prostorech, kdy jsou slova nebo činy jednotlivého účastníka komunity CNCF cíleny na projekt CNCF, komunitu CNCF nebo jiného účastníka komunity CNCF nebo se jich týkají.
 
-Tento kodex chování platí jak v prostorech projektu, tak ve veřejných prostorách, když jednotlivec zastupuje projekt nebo jeho komunitu.
+## Akce CNCF
 
-Případy zneužívajícího, obtěžujícího nebo jinak nepřijatelného chování v Kubernetes lze nahlásit kontaktováním Výboru pro kodex chování Kubernetes na adrese behavior@kubernetes.io. Pokud jde o další projekty, kontaktujte správce projektu CNCF nebo našeho mediátora Mishi Choudhary mishi@linux.com.
+Akce CNCF, které produkuje Linux Foundation s profesionály najatými na akce, řídí [Kodex chování na akcích](https://events.linuxfoundation.org/code-of-conduct/) Linux Foundation dostupný na stránce akce. Je navržen tak, aby se používal ve spojení s Kodexem chování CNCF.
 
-Tento kodex chování je převzat z Paktu přispěvatelů (http://contributor-covenant.org), verze 1.2.0, k dispozici na http://contributor-covenant.org/version/1/2/0/
+## Naše normy
 
-### Kodex chování událostí CNCF
+Komunita CNCF je otevřená, inkluzivní a zdvořilá. Každý člen komunity má právo, aby byla respektována jeho identita.
 
-Události CNCF se řídí Kodexem chování Linux Foundation, který je k dispozici na stránce události. Toto je navrženo tak, aby bylo kompatibilní s výše uvedenými zásadami, a zahrnuje také další podrobnosti o reakci na incidenty.
+Mezi příklady chování, které přispívá k pozitivnímu prostředí, patří mimo jiné:
+
+* Projevování empatie a laskavosti vůči ostatním lidem
+* Respekt k jiným názorům, úhlům pohledu a zkušenostem
+* Poskytování a kultivované přijímání konstruktivní zpětné vazby
+* Přijímání odpovědnosti a omluva těm, na které mají vliv naše chyby, a poučení se z této zkušenosti
+* Soustředění se na to, co je nejlepší nejen pro nás jako jednotlivce, ale pro celou komunitu
+* Používání laskavého a inkluzivního jazyka
+
+Mezi příklady nepřijatelného chování patří mimo jiné:
+
+* Používání sexualizovaného jazyka nebo obrázků
+* Trolling, urážlivé nebo hanlivé komentáře a osobní nebo politické útoky
+* Veřejné nebo soukromé obtěžování v jakékoli formě
+* Zveřejňování osobních informací jiných lidí, jako je fyzická nebo e-mailová adresa, pokud vám to vysloveně nepovolí
+* Násilí, vyhrožování násilím nebo podněcování ostatních k tomu, aby se zapojili do násilného chování
+* Stalking nebo sledování někoho bez jeho souhlasu
+* Nevítaný fyzický kontakt
+* Nevítaný sexuální nebo romantický zájem nebo návrhy
+* Jiné chování, které by mohlo být oprávněně pokládáno za nevhodné v profesionálním prostředí
+
+Navíc je zakázáno i toto chování:
+
+* Poskytování vědomě nesprávných nebo zavádějících informací ve spojení s vyšetřováním souvisejícím s Kodexem chování nebo jiné úmyslné zasahování do vyšetřování.
+* Protiopatření proti osobě, která nahlásila incident nebo poskytla informace o incidentu jako svědek.
+
+Správci projektu mají právo a odpovědnost odstranit, upravit nebo odmítnout komentáře, závazky, kód, úpravy na wikipedii, problémy a další příspěvky, které nejsou v souladu s tímto Kodexem chování. Přijetím tohoto Kodexu chování se správci projektu zavazují, že budou spravedlivě a konzistentně aplikovat tyto principy na každý aspekt správy projektu CNCF. Správci projektu, kteří se neřídí Kodexem chování nebo jeho dodržování neprosazují, mohou být dočasně nebo trvale vyloučeni z projektového týmu.
+
+## Hlášení událostí
+
+Pro incidenty v komunitě Kubernetes kontaktujte [Výbor pro Kodex chování Kubernetes](https://git.k8s.io/community/committee-code-of-conduct) na adrese [conduct@kubernetes.io](mailto:conduct@kubernetes.io). Odpověď můžete očekávat do tří pracovních dnů.
+
+Pro jiné projekty nebo pro incidenty, které jsou vůči projektu agnostické nebo mají vliv na více projektů CNCF, prosím kontaktujte [Výbor pro Kodex chování CNCF](https://www.cncf.io/conduct/committee/) prostřednictvím [conduct@cncf.io](mailto:conduct@cncf.io). Případně můžete kontaktovat kohokoliv z jednotlivých členů [Výboru pro Kodex chování CNCF](https://www.cncf.io/conduct/committee/) a odeslat svou zprávu. Podrobnější pokyny k tomu, jak odeslat zprávu, včetně toho, jak ji odeslat anonymně, viz naše [Postupy řešení incidentů](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md). Odpověď můžete očekávat do tří pracovních dnů.
+
+V případě incidentů, ke kterým dojde na akci CNCF produkované prostřednictvím Linux Foundation, prosím kontaktujte [eventconduct@cncf.io](mailto:conduct@cncf.io).
+
+## Prosazování
+
+Po posouzení a vyšetřování nahlášeného incidentu tým odezvy Kodexu chování v příslušné jurisdikci určí, jaká je odpovídající akce, na základě tohoto Kodexu chování a jeho související dokumentace.
+
+Pro informace o tom, které incidenty související s Kodexem chování řeší vedení projektu, které incidenty řeší Výbor pro Kodex chování CNCF a které incidenty řeší Linux Foundation (včetně jejích týmů pro akce), viz naše [Zásady jurisdikce](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md).
+
+## Dodatky
+
+Abychom byli v souladu s Chartou CNCF, jakékoli podstatné změny tohoto Kodexu chování musí schválit Výbor pro technický dohled.
+
+## Poděkování
+
+Tento Kodex chování je adaptací ze smlouvy o přispěvatelích ([http://contributor-covenant.org](http://contributor-covenant.org/)), verze 2.0 dostupné na [http://contributor-covenant.org/version/2/0/code_of_conduct/](http://contributor-covenant.org/version/2/0/code_of_conduct/)


### PR DESCRIPTION
Updating Czech translation.

The CNCF has had a professional translation service provide this version of the code of conduct.

Deploy preview: https://github.com/nate-double-u/cncf-foundation/blob/2024-02-09-NW-code-of-conduct-translation-update-Czech/code-of-conduct-languages/cs.md

Note: I didn't do the translation on this (just providing the markdown), but comments are welcome!

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206550547415097
  - https://app.asana.com/0/0/1206616792109812