### PR TITLE
docs: Include "KEDA" in preferred capitalization

### DIFF
--- a/style-guide.md
+++ b/style-guide.md
@@ -44,7 +44,7 @@ middle of the word ("ubernete") with the number of letters it contains (8). K8s 
 
 ## 3. Other CNCF Projects ##
 
-Different CNCF-hosted projects have preferred capitalization (e.g., containerd, gRPC). Please see
+Different CNCF-hosted projects have preferred capitalization (e.g., containerd, gRPC, KEDA). Please see
 [https://www.cncf.io/projects/](https://www.cncf.io/projects/).
 
 ## 4. Logos ##


### PR DESCRIPTION
Include "KEDA" in preferred capitalization to ensure that new press releases respect it, although https://www.cncf.io/projects/keda/ already has it correct