### PR TITLE
Updating code of conduct translation: French

### DIFF
--- a/code-of-conduct-languages/fr.md
+++ b/code-of-conduct-languages/fr.md
@@ -1,34 +1,66 @@
-Ce texte est également disponible à l'adresse suivante: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
+## Code de conduite de la communauté
 
-À TRADUIRE :
-------------
+En tant que contributeurs, éditeurs et participants de la communauté CNCF, et afin d’encourager le développement d’une communauté ouverte et accueillante, nous nous engageons à respecter chaque personne qui apporte sa contribution en signalant des incidents, en publiant des suggestions de fonctionnalités, en mettant à jour la documentation, en envoyant des demandes de tirage ou en assistant à des conférences ou à des événements, ou en participant à d’autres activités communautaires ou de projet.
 
-Code de conduite de la communauté de la CNCF v1.0
--------------------------------------------------
+Nous mettons tout en œuvre afin que la participation au sein de la communauté CNCF ne soit source de désagrément pour personne, quels que soient l’âge, la corpulence, la classe sociale, la situation de handicap, l’ethnie, le niveau d’expérience, la situation familiale, le sexe, l’identité et l’expression de genre, l’état civil, le statut militaire ou d’ancien combattant, la nationalité, l’apparence personnelle, la couleur de peau, la religion, l’orientation sexuelle, le statut socio-économique, la culture, ou toute autre dimension de la diversité.
 
-### Code de conduite des contributeurs
+## Champ d’application
 
-En tant que contributeurs et éditeurs dans le cadre de ce projet, et afin d’encourager le développement d’une communauté ouverte et accueillante, nous nous engageons à respecter chaque personne qui apporte sa contribution en signalant des problèmes, en publiant des suggestions de fonctionnalités, en mettant à jour la documentation, en envoyant des demandes de tirage ou sous une autre forme.
+Le présent Code de conduite s’applique :
+* au sein des projets et des espaces communautaires ;
+* au sein d’autres espaces, lorsque les mots ou les actions d’un participant de la communauté de la CNCF sont adressés à un projet de la CNCF, à la communauté de la CNCF ou à un autre participant de la communauté de la CNCF.
 
-Nous mettons tout en œuvre afin que la participation à ce projet ne soit source de désagrément pour personne, quel que soit le niveau d’expérience, le sexe, l’identité, l’expression ou l’orientation sexuelle, le handicap, l’apparence physique, la taille et/ou le poids, l’origine ethnique, l’âge, la religion ou la nationalité des personnes qui y participent.
+## Événements de la CNCF
 
-Voici quelques exemples de comportements qui ne seront pas acceptés de la part des participants:
+Les événements de la CNCF produits avec une équipe professionnelle sont régis par les [Événements du Code de conduite](https://events.linuxfoundation.org/code-of-conduct/) de la Linux Foundation, disponible sur la page des événements. Ce dernier est conçu pour être utilisé en association avec le Code de conduite de la CNCF.
 
--	l’utilisation de propos ou d’images à caractère sexuel ;
--	les critiques personnelles ;
--	les commentaires provocateurs, insultants ou péjoratifs ;
--	le harcèlement en public ou en privé ;
--	la publication, sans autorisation expresse, d’informations privées de tiers, telles que l’adresse postale ou l’adresse e-mail ;
--	tout autre comportement contraire à l’éthique ou non professionnel.
+## Nos principes
 
-Les éditeurs du projet ont le droit et la responsabilité de retirer, modifier ou rejeter les commentaires, les validations, le code, les modifications de wiki, les problèmes et toute autre contribution qui ne respecte pas ce Code de conduite. En adoptant ce Code de conduite, les éditeurs du projet s’engagent eux-mêmes à appliquer ces principes de manière juste et systématique dans tous les aspects de la gestion du projet. Les éditeurs du projet qui ne respectent pas le Code de conduite ou ne le font pas respecter pourront être retirés définitivement de l’équipe du projet.
+La communauté de la CNCF est ouverte, inclusive et respectueuse. Chacun des membres de notre communauté dispose d’un droit au respect de son identité.
 
-Ce Code de conduite s’applique à la fois dans le cadre du projet et dans le cadre public, lorsqu’une personne représente le projet ou la communauté.
+Voici quelques exemples de comportements qui contribuent à un environnement positif :
+* Faire preuve d’empathie et de gentillesse vis-à-vis des autres
+* Respecter les opinions, les points de vue et les expériences divergents
+* Donner et accepter avec bienveillance un commentaire constructif
+* Accepter de prendre ses responsabilités, s’excuser auprès des personnes affectées par nos erreurs et tirer les enseignements de l’expérience
+* Se concentrer sur ce qui semble le mieux pour soi-même en tant qu’individu, mais aussi pour l’ensemble de la communauté
+* Utiliser des termes conviviaux et inclusifs
 
-Des cas de conduite abusive, de harcèlement ou autre pratique inacceptable ayant cours sur Kubernetes peuvent être signalés en contactant le [comité pour le code de conduite de Kubernetes](https://git.k8s.io/community/committee-code-of-conduct) via l'adresse <conduct@kubernetes.io>.  Pour d'autres projets, bien vouloir contacter un responsable de projet CNCF ou notre médiateur, Mishi Choudhary à l'adresse <mishi@linux.com>. 
+Voici quelques exemples de comportements inacceptables :
+* Le recours à un langage ou à des images à connotation sexuelle
+* Le harcèlement, les commentaires insultants ou désobligeants et les attaques personnelles ou politiques
+* Le harcèlement public ou privé sous quelque forme que ce soit
+* La publication de données à caractère privé, telles qu’une adresse physique ou électronique, sans l’autorisation préalable d’autrui
+* La violence, la menace de violence ou le fait d’encourager d’autres personnes à adopter un comportement violent
+* Le harcèlement ou le fait de suivre quelqu’un sans son consentement
+* Le contact physique non désiré
+* L’attention, les avances sexuelles ou romantiques non désirées
+* Tout autre comportement qui pourrait être considéré de manière raisonnable comme inapproprié dans un cadre professionnel
 
-Ce Code de conduite est inspiré du « Contributor Covenant » (http://contributor-covenant.org) version 1.2.0, disponible à l’adresse http://contributor-covenant.org/version/1/2/0/.
+Les comportements suivants sont également interdits :
+* Fournir intentionnellement des informations fausses ou fallacieuses dans le cadre d’une enquête menée en vertu du Code de conduite ou falsifier délibérément une enquête.
+* Prendre des mesures de représailles à l’encontre d’une personne pour avoir signalé un incident ou fourni des informations sur un incident en tant que témoin.
 
-### Code de conduite pour les événements de la CNCF
+Les responsables du projet ont le droit et la responsabilité de retirer, de modifier ou de rejeter les commentaires, les validations, le code, les modifications du wiki, les incidents et toute autre contribution qui ne sont pas conformes au présent Code de conduite. En adoptant ce Code de conduite, les responsables de projets s’engagent à appliquer ces principes de manière impartiale et cohérente à tous les aspects de la gestion d’un projet de la CNCF. Les responsables de projets qui ne respectent pas ou enfreignent le Code de conduite peuvent être retirés temporairement ou définitivement de l’équipe de projet.
 
-Les événements de la CNCF sont régis par le Code de conduite de The Linux Foundation, disponible sur la page des événements. Ce Code est compatible avec la politique ci-dessus et inclut davantage de détails sur la façon de gérer les incidents.
+## Rapports
+
+Pour les incidents qui surviennent au sein de la communauté Kubernetes, contactez le [Comité du Code de conduite de Kubernetes](https://git.k8s.io/community/committee-code-of-conduct) via [conduct@kubernetes.io](mailto:conduct@kubernetes.io). Une réponse devrait vous parvenir dans un délai de trois jours ouvrables.
+
+Pour d’autres projets, ou pour des incidents indépendants des projets ou ayant un impact sur plusieurs projets de la CNCF, contactez le [Comité du Code de conduite de la CNCF](https://www.cncf.io/conduct/committee/) via [conduct@cncf.io](mailto:conduct@cncf.io). Vous pouvez également contacter l’un des membres du [Comité du Code de conduite de la CNCF](https://www.cncf.io/conduct/committee/) pour présenter votre rapport. Veuillez consulter nos [Procédures de résolution des incidents](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md), pour plus de détails sur la manière de présenter un rapport, y compris de manière anonyme. Une réponse devrait vous parvenir dans un délai de trois jours ouvrables.
+
+Pour signaler tout incident survenu lors d’un événement de la CNCF produit par la Linux Foundation, veuillez contacter [eventconduct@cncf.io](mailto:eventconduct@cncf.io).
+
+## Mise en application
+
+Après avoir étudié et vérifié tout incident signalé, l’équipe chargée de l’application du Code de conduite qui est compétente déterminera les mesures à prendre sur la base du présent Code de conduite et de la documentation qui s’y rapporte.
+
+Pour savoir quels incidents liés au Code de conduite sont du ressort de la direction du projet, quels incidents sont du ressort du Comité du Code de conduite de la CNCF et quels incidents sont du ressort de la Linux Foundation (y compris de son équipe chargée des événements), veuillez consulter notre [Politique en matière de compétence](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md).
+
+## Amendements
+
+Conformément à la charte de la CNCF, toute modification substantielle du présent Code de conduite doit être approuvée par le Comité de supervision technique.
+
+## Mentions
+
+Ce Code de conduite est inspiré du « Contributor Covenant » ([http://contributor-covenant.org](http://contributor-covenant.org/)) version 2.0, disponible à l’adresse [http://contributor-covenant.org/version/2/0/code_of_conduct/](http://contributor-covenant.org/version/2/0/code_of_conduct/).


### PR DESCRIPTION
Updating French translation.

The CNCF has had a professional translation service provide this version of the code of conduct.

Deploy preview: https://github.com/nate-double-u/cncf-foundation/blob/2024-03-25-NW-code-of-conduct-translation-update-French/code-of-conduct-languages/fr.md

Note: I didn't do the translation on this (just providing the markdown), but comments are welcome!
