### PR TITLE
Updating code of conduct translation: German

### DIFF
--- a/code-of-conduct-languages/de.md
+++ b/code-of-conduct-languages/de.md
@@ -1,29 +1,66 @@
-CNCF Gemeinschafts-Verhaltenskodex v1.0
----------------------------------------
+## Gemeinschafts-Verhaltenskodex
 
-### Verhaltenskodex für Mitwirkende
+Als Mitwirkende, Betreuer und Teilnehmer der CNCF-Gemeinschaft und im Interesse der Förderung einer offenen und einladenden Gemeinschaft verpflichten wir uns dazu, alle Menschen zu respektieren, die sich durch Berichterstattung, Veröffentlichung von Eigenschaftsanfragen, Aktualisierung der Dokumentation, Einreichung von Pull-Anfragen oder Patches, Teilnahme an Konferenzen oder Veranstaltungen und anderen Aktivitäten der Gemeinschaft oder des Projekts beteiligen oder einen Beitrag leisten.
 
-Als Mitwirkende und Betreuer dieses Projekts und im Interesse der Förderung einer offenen und einladenden Gemeinschaft verpflichten wir uns dazu, alle Menschen zu respektieren, die durch Berichterstattung, Veröffentlichung von Eigenschaftsanfragen, Aktualisierung der Dokumentation, Einreichung von Pull-Anfragen oder Patches und anderen Aktivitäten einen Beitrag leisten.
+Wir sind bestrebt, die Teilnahme an der CNCF-Gemeinschaft für alle zu einer belästigungsfreien Erfahrung zu machen, unabhängig von Alter, Körpergröße, Kaste, Behinderung, ethnischer Zugehörigkeit, Erfahrungsstand, Familienstand, Geschlecht, geschlechtsspezifischer Identität und geschlechtsspezifischem Ausdruck, Familienstand, Militär- oder Veteranenstatus, Nationalität, persönlichem Aussehen, Ethnie, Religion, sexueller Orientierung, sozioökonomischem Status, Stammeszugehörigkeit oder jeder anderen Dimension der Vielfalt.
 
-Wir sind bestrebt, die Teilnahme an diesem Projekt für alle zu einer belästigungsfreien Erfahrung zu machen, unabhängig von Erfahrungsstand, Geschlecht, geschlechtsspezifischer Identität und Ausdruck, sexueller Orientierung, Behinderung, persönlichem Aussehen, Körpergröße, Rasse, ethnischer Herkunft, Alter, Religion oder Nationalität.
+## Geltungsbereich
 
-Beispiele für unzumutbares Verhalten der Teilnehmer sind:
+Dieser Verhaltenskodex gilt:
+* innerhalb von Projekten und Gemeinschaftsräumen,
+* in anderen Bereichen, wenn die Worte oder Handlungen eines einzelnen Teilnehmers der CNCF-Gemeinschaft an ein CNCF-Projekt, die CNCF-Gemeinschaft oder einen anderen Teilnehmer der CNCF-Gemeinschaft gerichtet sind oder sich darauf beziehen.
 
--	Der Gebrauch von sexualisierter Sprache oder Bildern
--	Persönliche Angriffe
--	Trolling oder beleidigende/herabwürdigende Kommentare
--	Öffentliche oder private Belästigungen
--	Veröffentlichung privater Informationen anderer, wie z.B. physischer oder elektronischer Adressen, ohne ausdrückliche Genehmigung
--	Anderes unethisches oder unprofessionelles Verhalten.
+## CNCF-Veranstaltungen
 
-Projektbetreuer haben das Recht und die Verantwortung, Kommentare, Commits, Code, Wiki-Bearbeitungen, Probleme und andere Beiträge zu entfernen, zu bearbeiten oder abzulehnen, die nicht mit diesem Verhaltenskodex übereinstimmen. Mit der Annahme dieses Verhaltenskodex verpflichten sich die Projektbetreuer, diese Grundsätze fair und konsequent auf jeden Aspekt der Projektleitung anzuwenden. Projektbetreuer, die den Verhaltenskodex nicht befolgen oder durchsetzen, können dauerhaft vom Projektteam ausgeschlossen werden.
+Für CNCF-Veranstaltungen, die von der Linux-Stiftung mit professionellem Veranstaltungspersonal durchgeführt werden, gilt der [Verhaltenskodex für Veranstaltungen](https://events.linuxfoundation.org/code-of-conduct/) der Linux-Stiftung, der auf der Veranstaltungsseite verfügbar ist. Dieser soll in Verbindung mit dem CNCF-Verhaltenskodex angewandt werden.
 
-Dieser Verhaltenskodex gilt sowohl innerhalb von Projekträumen als auch in öffentlichen Räumen, wenn eine Person das Projekt oder seine Gemeinschaft vertritt.
+## Unsere Standards
 
-Fälle von missbräuchlichem, belästigendem oder anderweitig unzumutbarem Verhalten in Kubernetes können gemeldet werden, indem Sie sich an das [Kubernetes Komitee für Verhaltenskodex](https://git.k8s.io/community/committee-code-of-conduct) wenden unter <conduct@kubernetes.io>. Für andere Projekte wenden Sie sich bitte an einen CNCF-Projektbetreuer oder an unseren Mediator, Mishi Choudhary <mishi@linux.com>.
+Die CNCF-Gemeinschaft ist offen, inklusiv und respektvoll. Jedes Mitglied unserer Gemeinschaft hat das Recht, dass seine Identität respektiert wird.
 
-Dieser Verhaltenskodex wurde aus dem Contributor Covenant übernommen (http://contributor-covenant.org), Version 1.2.0, verfügbar unter http://contributor-covenant.org/version/1/2/0/
+Beispiele für ein Verhalten, das zu einem positiven Umfeld beiträgt, sind unter anderem:
+* Einfühlungsvermögen und Freundlichkeit gegenüber anderen Menschen zeigen
+* Unterschiedliche Meinungen, Standpunkte und Erfahrungen respektieren
+* Konstruktives Feedback geben und mit Anstand annehmen
+* Verantwortung übernehmen und sich bei denjenigen entschuldigen, die von unseren Fehlern betroffen sind, und aus der Erfahrung lernen
+* Sich auf das konzentrieren, was nicht nur für uns als Individuen, sondern für die gesamte Gemeinschaft am besten ist
+* Eine einladende und inklusive Sprache verwenden
 
-### CNCF Verhaltenskodex für Veranstaltungen
+Beispiele für inakzeptables Verhalten sind unter anderem:
+* Der Gebrauch von sexualisierter Sprache oder Bildern
+* Trolling, beleidigende oder herabwürdigende Kommentare und persönliche oder politische Angriffe
+* Öffentliche oder private Belästigung in jeder Form
+* Die Veröffentlichung privater Informationen anderer, wie z. B. einer physischer oder E-Mail-Adresse, ohne deren ausdrückliche Genehmigung
+* Gewalt, Androhung von Gewalt oder Aufforderung anderer zu gewalttätigem Verhalten
+* Stalking oder Verfolgung von Personen ohne deren Zustimmung
+* Unerwünschter Körperkontakt
+* Unerwünschte sexuelle oder romantische Avancen/Annäherungsversuche
+* Sonstiges Verhalten, das in einem beruflichen Umfeld als unangemessen angesehen werden könnte
 
-Für CNCF Veranstaltungen gilt der Verhaltenskodex der Linux Foundation, der auf der Veranstaltungsseite verfügbar ist. Diese ist so konzipiert, dass sie mit der oben genannten Richtlinie kompatibel ist und enthält auch weitere Details zur Reaktion auf Vorfälle.
+Die folgenden Verhaltensweisen sind ebenfalls verboten:
+* Wissentlich falsche oder irreführende Angaben im Zusammenhang mit einer Untersuchung zum Verhaltenskodex oder eine anderweitige absichtliche Manipulation einer Untersuchung
+* Vergeltungsmaßnahmen gegen eine Person, weil sie einen Vorfall gemeldet oder Informationen über einen Vorfall als Zeuge zur Verfügung gestellt hat
+
+Projektbetreuer haben das Recht und die Verantwortung, Kommentare, Commits, Code, Wiki-Bearbeitungen, Probleme und andere Beiträge zu entfernen, zu bearbeiten oder abzulehnen, die nicht mit diesem Verhaltenskodex übereinstimmen. Mit der Annahme dieses Verhaltenskodex verpflichten sich die Projektbetreuer, diese Grundsätze fair und konsequent auf jeden Aspekt der Leitung eines CNCF-Projekts anzuwenden. Projektbetreuer, die den Verhaltenskodex nicht befolgen oder durchsetzen, können vorübergehend oder dauerhaft vom Projektteam ausgeschlossen werden.
+
+## Berichterstattung
+
+Bei Vorfällen in der Kubernetes-Gemeinschaft wenden Sie sich bitte an das [Kubernetes-Komitee für Verhaltenskodex](https://git.k8s.io/community/committee-code-of-conduct) unter [conduct@kubernetes.io](mailto:conduct@kubernetes.io). Sie können innerhalb von drei Werktagen mit einer Antwort rechnen.
+
+Bei anderen Projekten oder bei Vorfällen, die projektunabhängig sind oder mehrere CNCF-Projekte betreffen, wenden Sie sich bitte an das [Komitee für den CNCF-Verhaltenskodex](https://www.cncf.io/conduct/committee/) unter [conduct@cncf.io](mailto:conduct@cncf.io). Alternativ können Sie sich auch an irgendein einzelnes Mitglied des [Komitees für den CNCF-Verhaltenskodex](https://www.cncf.io/conduct/committee/) wenden, um Ihren Bericht einzureichen. Ausführlichere Anweisungen zum Einreichen eines Berichts, einschließlich der Möglichkeit, anonym Bericht zu erstatten, finden Sie in unseren [Verfahren zur Lösung von Vorfällen](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md). Sie können innerhalb von drei Werktagen mit einer Antwort rechnen.
+
+Bei Vorfällen, die sich auf einer CNCF-Veranstaltung ereignen, die von der Linux-Stiftung durchgeführt wird, schreiben Sie bitte an [eventconduct@cncf.io](mailto:eventconduct@cncf.io).
+
+## Durchsetzung
+
+Nach Prüfung und Untersuchung eines gemeldeten Vorfalls entscheidet das zuständige CoC-Reaktionsteam, welche Maßnahmen auf der Grundlage dieses Verhaltenskodex und der zugehörigen Dokumentation angemessen sind.
+
+Informationen darüber, welche Vorfälle im Zusammenhang mit dem Verhaltenskodex von der Projektleitung, welche vom Komitee für den CNCF-Verhaltenskodex und welche von der Linux-Stiftung (einschließlich ihres Veranstaltungsteams) bearbeitet werden, finden Sie in unserer [Zuständigkeitsrichtlinie](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md).
+
+## Ergänzungen
+
+In Übereinstimmung mit der CNCF-Charta müssen alle wesentlichen Änderungen an diesem Verhaltenskodex vom Technischen Überwachungsausschuss genehmigt werden.
+
+## Danksagung
+
+Dieser Verhaltenskodex wurde aus dem Contributor Covenant übernommen ([http://contributor-covenant.org](http://contributor-covenant.org/)), Version 2.0, verfügbar unter [http://contributor-covenant.org/version/2/0/code_of_conduct/](http://contributor-covenant.org/version/2/0/code_of_conduct/)


### PR DESCRIPTION
Updating German translation.

The CNCF has had a professional translation service provide this version of the code of conduct.

Deploy preview: https://github.com/nate-double-u/cncf-foundation/blob/2024-03-25-NW-code-of-conduct-translation-update-German/code-of-conduct-languages/de.md

Note: I didn't do the translation on this (just providing the markdown), but comments are welcome!
