### PR TITLE
Updating code of conduct translation: Italian

### DIFF
--- a/code-of-conduct-languages/it.md
+++ b/code-of-conduct-languages/it.md
@@ -1,27 +1,66 @@
-CNCF Codice di condotta comunitaria v1.0
-----------------------------------------
+## Codice di condotta comunitaria
 
-### Codice di condotta dei collaboratori 
+Come collaboratori, responsabili e partecipanti della comunità CNF e al fine di promuovere una comunità accogliente e aperta, ci impegniamo a rispettare tutti coloro che partecipano o offrono il proprio contributo segnalando problemi, condividendo richieste, aggiornando la documentazione, inviando richieste o patch, partecipando a conferenze o eventi o prendendo parte ad altre attività relative a progetti o alla comunità.
 
-Come collaboratori e responsabili di questo progetto, per creare un ambiente accogliente e aperto, ci impegniamo a rispettare tutte le persone che contribuiranno a segnalare dei problemi, condividendo richieste, aggiornando la documentazione, inviando richieste o patch e altre attività.
+Ci impegniamo a far sì che la partecipazione alla comunità CNF sia un’esperienza senza alcun tipo di molestie, indipendentemente da fattori quali età, corporatura, estrazione sociale, disabilità, etnia, livello di esperienza, condizione familiare, genere, identità o espressione di genere, stato coniugale, nazionalità, aspetto fisico, razza, religione, orientamento sessuale, stato socioeconomico, appartenenza tribale o qualsiasi altra caratterizzazione distintiva.
 
-Ci impegniamo a far si che la partecipazione ai progetti CNCF sia un’esperienza senza alcun tipo di molestia, indipendentemente dal livello di esperienza, genere, espressione, orientamento sessuale, disabilità, apparenza fisica, taglia, razza, etnia, età, religione o nazionalità.
+## Ambito
 
-Esempi di comportamenti inaccettabili includono:
+Il presente Codice di condotta si applica:
+* nell’ambito delle attività di progetto e della comunità,
+* in altre aree in cui le parole o le azioni dei singoli partecipanti alla comunità CNCF sono dirette o relative a un progetto CNCF, alla comunità CNCF o ad un altro partecipante alla comunità CNCF.
 
--	Uso di linguaggio o immagini volgari
--	Attacchi personali
--	Trolling o commenti dispregiativi
--	Molestie privato o pubbliche
--	Pubblicazione di informazioni personali, come indirizzi di posta elettronica o indirizzi di residenza, senza permesso esplicito
--	Altri tipi di condotta non etica o non professionale
+## Eventi CNFC
 
-I responsabili di progetto hanno il diritto e la responsabilità di rimuovere, modificare o respingere commenti, aggressioni, codice, wiki edit, reclami e altri contributi che non siano allineati con questo codice di condotta. Adottando il codice di condotta, i responsabili del progetto si impegnano ad applicare questi principi in prima persona e a ogni aspetto della gestione del progetto. I responsabili che non seguiranno o non faranno rispettare il codice di condotta saranno rimossi dal team. Questo codice di condotta verrà applicato a chiunque contribuisca o rappresenti un progetto o la sua comunità in pubblico.
+Gli eventi CNCF gestiti da Linux Foundation con personale professionistico per l’organizzazione di eventi sono disciplinati dal [Codice di condotta negli eventi](https://events.linuxfoundation.org/code-of-conduct/) di Linux Foundation, disponibile nella pagina dell'evento. Tale codice va utilizzato congiuntamente al Codice di condotta CNCF.
 
-Casi di comportamenti abusivi, molestie o altri comportamenti inaccettabili in Kubernetes potranno essere denunciati contattando [Il comitato del codice di condotta Kubernetes (CNCF)](https://git.k8s.io/community/committee-code-of-conduct) attraverso <conduct@kubernetes.io>. Per altri progetti, contattare il Project manager del CNCF o il nostro mediatore, Mishi Choudhary <mishi@linux.com>. 
+## I nostri standard
 
-Il codice di condotta è stato adattato dal Contributor Covenant (http://contributor-covenant.org), versione 1.2.0, disponibile su http://contributor-covenant.org/version/1/2/0/
+La comunità CNCF è aperta, inclusiva e rispettosa. Ciascun membro della nostra comunità ha il diritto di vedere la propria identità rispettata.
 
-### CNCF Codice di condotta negli eventi
+Alcuni esempi di comportamenti che contribuiscono a creare un ambiente positivo sono:
+* Dimostrare empatia e gentilezza nei confronti degli altri
+* Rispettare opinioni, mentalità ed esperienze diverse dalle proprie
+* Fornire e accettare di buon grado feedback costruttivo
+* Accettare le proprie responsabilità e chiedere scusa a coloro che subiscono le conseguenze dei nostri errori, nonché imparare dall'esperienza
+* Concentrarsi su ciò che è meglio non solo per noi come singole persone, ma per la comunità nel suo complesso
+* Utilizzare un linguaggio accogliente e inclusivo
 
-Gli eventi CNCF sono gestiti da Linux Foundation Codice di Condotta disponibile sulla pagina dell'evento. Questo è compatibile con quanto descritto sopra e include maggiori dettagli sulla gestione degli incidenti.
+Alcuni esempi di comportamenti inaccettabili sono:
+* Uso di linguaggio o immagini volgari
+* Trolling, commenti offensivi o dispregiativi e attacchi personali o politici
+* Qualsiasi forma di molestia privata o pubblica
+* Pubblicazione di dati personali altrui, come indirizzi di posta elettronica o indirizzi di residenza, senza il loro esplicito permesso
+* Comportamenti violenti, minacce di violenza o istigazione all’adozione di comportamenti violenti
+* Perseguitare o seguire qualcuno senza il suo consenso
+* Contatto fisico indesiderato
+* Approcci romantici o sessuali indesiderati
+* Altri comportamenti che potrebbero essere ragionevolmente considerati inappropriati in un contesto professionale
+
+Sono inoltre vietati i seguenti comportamenti:
+* Fornire informazioni consapevolmente false o fuorvianti in relazione a un'indagine inerente al Codice di condotta, o depistare intenzionalmente in altro modo un’indagine.
+* Applicare ritorsioni contro una persona che ha segnalato un incidente o fornito informazioni su un incidente in qualità di testimone.
+
+I responsabili di progetto hanno il diritto e la responsabilità di rimuovere, modificare o rifiutare commenti, azioni, codice, modifiche wiki, problematiche e altri contributi non in linea con il presente Codice di condotta. Adottando il presente Codice di condotta, i responsabili di progetto si impegnano ad applicare questi principi a ogni aspetto della gestione di un progetto CNCF. I responsabili di progetto che non seguono o non fanno rispettare il Codice di condotta saranno rimossi dal team del progetto a titolo temporaneo o definitivo.
+
+## Segnalazioni
+
+Per incidenti verificatisi all’interno della comunità Kubernetes, contattare il [Comitato del codice di condotta Kubernetes](https://git.k8s.io/community/committee-code-of-conduct) attraverso [conduct@kubernetes.io](mailto:conduct@kubernetes.io). Di norma si riceverà una risposta entro tre giorni lavorativi.
+
+Per altri progetti, o per incidenti non relativi a progetti o che interessano più progetti CNCF, contattare il [Comitato del codice di condotta CNCF](https://www.cncf.io/conduct/committee/) attraverso [conduct@cncf.io](mailto:conduct@cncf.io). In alternativa, è possibile contattare singoli esponenti del [Comitato del codice di condotta CNCF](https://www.cncf.io/conduct/committee/) e inviare loro la propria segnalazione. Per istruzioni più dettagliate su come inviare una segnalazione, ivi incluse informazioni su come inviare una segnalazione anonima, consultare le nostre [Procedure per la risoluzione degli incidenti](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md). Di norma si riceverà una risposta entro tre giorni lavorativi.
+
+Per incidenti verificatisi in occasione di un evento CNCF gestito da Linux Foundation, contattare [eventconduct@cncf.io](mailto:eventconduct@cncf.io).
+
+## Applicazione
+
+Al termine dell’esame e dell’indagine relativa ad un incidente segnalato, il team di risposta CdC competente stabilirà l’azione appropriata da intraprendere in base al presente Codice di condotta e alla relativa documentazione.
+
+Per informazioni su quali incidenti relativi al Codice di condotta sono gestiti dalla leadership di progetto, quali incidenti sono gestiti dal Comitato del Codice di condotta CNCF e quali incidenti sono gestiti dalla Linux Foundation (incluso il suo team eventi), consultare la nostra [Policy sulla competenza giurisdizionale](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md).
+
+## Emendamenti
+
+In conformità allo Statuto CNCF, qualsiasi modifica sostanziale al presente Codice di condotta deve essere approvata dal Comitato tecnico di vigilanza.
+
+## Riconoscimenti
+
+Il presente Codice di condotta è stato adattato dal Contributor Covenant ([http://contributor-covenant.org](http://contributor-covenant.org/)), versione 2.0, disponibile su [http://contributor-covenant.org/version/2/0/code_of_conduct/](http://contributor-covenant.org/version/2/0/code_of_conduct/)


### PR DESCRIPTION
Updating Italian translation.

The CNCF has had a professional translation service provide this version of the code of conduct.

Deploy preview: https://github.com/nate-double-u/cncf-foundation/blob/2024-03-25-NW-code-of-conduct-translation-update-Italian/code-of-conduct-languages/it.md

Note: I didn't do the translation on this (just providing the markdown), but comments are welcome!
