### PR TITLE
Updating code of conduct translation: Polish

### DIFF
--- a/code-of-conduct-languages/pl.md
+++ b/code-of-conduct-languages/pl.md
@@ -1,43 +1,66 @@
-## Kodeks Postępowania Społeczności CNCF v1.0
+## Kodeks postępowania społeczności
 
-### Kodeks postępowania współtwórców projektu
+Jako współtwórcy, administratorzy i uczestnicy społeczności CNCF w trosce o wspieranie otwartej i przyjaznej społeczności zobowiązujemy się szanować wszystkie osoby, które uczestniczą w społeczności lub wnoszą w nią swój wkład, poprzez zgłaszanie problemów, przesyłanie próśb o dodatkowe funkcjonalności, aktualizowanie dokumentacji, przesyłanie próśb o zaakceptowanie zmian (tzw. _pull requests_) lub poprawek, uczestnictwo w konferencjach lub wydarzeniach bądź angażowanie się w inne działania społeczności czy projektu.
 
-My, współtwórcy i gospodarze tego projektu, dbając o to, aby nasza społeczność była otwarta i przyjazna,
-zobowiązujemy się szanować wszystkich, którzy uczestniczą w projekcie
-zgłaszając problemy, prośby o dodatkowe funkcjonalności, aktualizując dokumentację,
-rozbudowując lub poprawiając oprogramowanie, a także angażując się na inne sposoby.
+Dokładamy wszelkich starań, aby uczestnictwo w społeczności CNCF było doświadczeniem wolnym od nękania dla wszystkich osób, bez względu na wiek, rozmiar ciała, kastę, niepełnosprawność, pochodzenie etniczne, poziom doświadczenia, status rodzinny, płeć, tożsamość i ekspresję płciową, stan cywilny, status wojskowy lub weterana, narodowość, wygląd osobisty, rasę, religię, orientację seksualną, status społeczno-ekonomiczny, plemię lub jakikolwiek inny wymiar odmienności.
 
-Staramy się, aby udział w tym projekcie był wolny od jakichkolwiek form nękania dla każdego,
-bez względu na doświadczenie, płeć, orientację i identyfikację seksualną,
-niepełnosprawność, wygląd zewnętrzny, budowę ciała, kolor skóry, pochodzenie etniczne, wiek,
-wyznawaną religię czy narodowość.
+## Zakres
 
-Przykładowe zachowania, które są nieakceptowalne:
+Niniejszy Kodeks postępowania ma zastosowanie:
+* w ramach projektu i przestrzeni społeczności;
+* w innych przestrzeniach, gdy słowa lub działania indywidualnego uczestnika społeczności CNCF odnoszą się do projektu CNCF, społeczności CNCF lub innego uczestnika społeczności CNCF bądź ich dotyczą.
 
-* Używanie języka lub obrazów o podtekście seksualnym,
-* Ataki osobiste,
-* Trollowanie, obraźliwe bądź urągające komentarze,
-* Nękanie, zarówno na forum publicznym, jak i prywatnie,
-* Publikowanie danych osobistych innych osób — takich jak adres fizyczny, czy elektroniczny —
-bez ich wyraźnej zgody,
-* Inne zachowania nieetyczne lub nieprofesjonalne.
+## Wydarzenia CNCF
 
-Opiekunowie projektu mają prawo i są odpowiedzialni za usuwanie, edycję oraz odrzucanie komentarzy,
-zmian w kodzie (*commits*), edycji Wiki, oraz innych treści, które łamią niniejszy Kodeks Postępowania.
-Przyjmując ten Kodeks Postępowania, opiekunowie projektu
-zobowiązali sie do rzetelnego i konsekwentnego stosowania tych zasad w każdym aspekcie
-zarządzania tym projektem. Opiekunowie projektu, którzy nie respektują i nie egzekwują Kodeksu Postępowania,
-mogą zostać na stałe usunięci z zespołu projektowego.
+Wydarzenia CNCF organizowane przez Linux Foundation z udziałem profesjonalnego personelu podlegają postanowieniom zawartym w [Kodeksie postępowania podczas wydarzeń](https://events.linuxfoundation.org/code-of-conduct/) Linux Foundation dostępnym na stronie internetowej poświęconej danemu wydarzeniu. Jest on przeznaczony do stosowania w powiązaniu z Kodeksem postępowania CNCF.
 
-Ten Kodeks Postępowania ma zastosowanie w obrębie projektu, a także w sferze publicznej,
-jeśli indywidualna osoba reprezentuje projekt lub jego społeczność.
+## Nasze standardy
 
-Przypadki nękania, gróźb oraz innych form nieakceptowalnego zachowania w projekcie Kubernetes mogą być zgłaszane poprzez kontakt z [Komitetem Kodeksu Postępowania](https://git.k8s.io/community/committee-code-of-conduct) pod adresem <conduct@kubernetes.io>. W przypadku innych projektów, prosimy o kontakt z opiekunem projektu z CNCF lub z naszą mediatorką, Mishi Choudhary <mishi@linux.com>.
+Społeczność CNCF ma charakter otwarty, integracyjny i pełen szacunku. Każdy członek naszej społeczności ma prawo do poszanowania własnej tożsamości.
 
-Ten Kodeks Postępowania jest adaptacją Contributor Covenant
-(http://contributor-covenant.org) w wersji 1.2.0, dostępnej na
-http://contributor-covenant.org/version/1/2/0/
+Przykładami zachowań, które przyczyniają się do tworzenia pozytywnego środowiska, są między innymi:
+* okazywanie empatii i życzliwości wobec innych ludzi;
+* poszanowanie odmiennych opinii, punktów widzenia i doświadczeń;
+* udzielanie konstruktywnych informacji zwrotnych i przyjmowanie ich z wdzięcznością;
+* podejmowanie odpowiedzialności i przepraszanie osób, na które wpłynęły nasze błędy, oraz wyciąganie wniosków z tych doświadczeń;
+* koncentrowanie się na tym, co jest najlepsze nie tylko dla nas jako jednostek, ale dla całej społeczności;
+* używanie przyjaznego i integrującego języka.
 
-### Kodeks postępowania dla wydarzeń organizowanych przez CNCF
+Przykładami niedopuszczalnych zachowań są między innymi:
+* używanie języka lub obrazów o charakterze seksualnym;
+* trollowanie, obraźliwe lub uwłaczające komentarze oraz ataki o charakterze osobistym lub politycznym;
+* publiczne lub prywatne nękanie w dowolnej postaci;
+* publikowanie prywatnych informacji innych osób, takich jak adres fizyczny lub adres e-mail, bez ich wyraźnej zgody;
+* przemoc, straszenie przemocą lub zachęcanie innych do zachowań przemocowych;
+* prześladowanie lub śledzenie innej osoby bez jej zgody;
+* niechciany kontakt fizyczny;
+* niechciane propozycje lub zainteresowanie o charakterze seksualnym lub romantycznym;
+* inne zachowania, które mogłyby zostać uznane za niewłaściwe w środowisku zawodowym.
 
-Wydarzenia organizowane przez CNCF podlegają [Kodeksowi Postępowania](https://events.linuxfoundation.org/code-of-conduct/) dostępnemu na stronie danego wydarzenia. Ma to na celu zapewnienie zgodności z powyższą polityką oraz zawiera szczegółowe wytyczne postępowania w przypadku zaistnienia niepożądanych incydentów.
+Zabronione są również następujące zachowania:
+* świadome dostarczanie fałszywych lub wprowadzających w błąd informacji w związku z dochodzeniem prowadzonym na podstawie Kodeksu postępowania lub celowe manipulowanie dochodzeniem w inny sposób;
+* działania odwetowe wobec osoby, która zgłosiła incydent lub przekazała informacje o incydencie, występując w charakterze świadka.
+
+Opiekunowie projektu są uprawnieni do usuwania, edytowania lub odrzucania komentarzy, zmian w kodzie (_commit_), kodu, edycji Wiki, zgłoszeń i innych form wkładu, które nie są zgodne z niniejszym Kodeksem postępowania, a także mają obowiązek wykonywać takie czynności. Akceptując niniejszy Kodeks postępowania, opiekunowie projektów zobowiązują się do uczciwego i konsekwentnego stosowania tych zasad w każdym aspekcie zarządzania projektem CNCF. Opiekunowie projektu, którzy nie przestrzegają lub nie egzekwują Kodeksu postępowania, mogą zostać tymczasowo lub na stałe wykluczeni z zespołu projektowego.
+
+## Zgłaszanie incydentów
+
+W przypadku incydentów występujących w społeczności Kubernetes należy skontaktować się z [Komitetem ds. Kodeksu postępowania Kubernetes](https://git.k8s.io/community/committee-code-of-conduct), wysyłając wiadomość na adres e-mail [conduct@kubernetes.io](mailto:conduct@kubernetes.io). Odpowiedzi można spodziewać się w ciągu trzech dni roboczych.
+
+W przypadku innych projektów lub incydentów, które nie są związane z projektem lub mają wpływ na wiele projektów CNCF, należy skontaktować się z [Komitetem ds. Kodeksu postępowania CNCF](https://www.cncf.io/conduct/committee/), wysyłając wiadomość na adres e-mail [conduct@cncf.io](mailto:conduct@cncf.io). Można również skontaktować się z którymkolwiek z członków [Komitetu ds. Kodeksu postępowania CNCF](https://www.cncf.io/conduct/committee/), aby przesłać swoje zgłoszenie. Więcej szczegółowych instrukcji dotyczących przesyłania zgłoszeń, w tym anonimowego ich przesyłania, można znaleźć w naszych [Procedurach rozwiązywania incydentów](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md). Odpowiedzi można spodziewać się w ciągu trzech dni roboczych.
+
+W przypadku incydentów mających miejsce podczas wydarzenia CNCF organizowanego przez Linux Foundation należy wysłać wiadomość na adres [eventconduct@cncf.io](mailto:eventconduct@cncf.io).
+
+## Egzekwowanie
+
+Po przeanalizowaniu i zbadaniu zgłoszonego incydentu właściwy zespół ds. reagowania na incydenty związane z Kodeksem postępowania określi, jakie działania są właściwe zgodnie z niniejszym Kodeksem postępowania i związaną z nim dokumentacją.
+
+Informacje na temat tego, które incydenty związane z Kodeksem postępowania są rozpatrywane przez kierownictwo projektu, które incydenty są rozpatrywane przez Komitet ds. Kodeksu postępowania CNCF, a które – przez Linux Foundation (w tym jej zespół ds. wydarzeń), można znaleźć w naszej [Polityce dotyczącej zakresu właściwości](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md).
+
+## Zmiany
+
+Zgodnie ze Statutem CNCF wszelkie istotne zmiany w niniejszym Kodeksie postępowania muszą być zatwierdzane przez Komitet ds. Nadzoru Technicznego.
+
+## Dokument odniesienia
+
+Niniejszy Kodeks postępowania został sporządzony na podstawie dokumentu Contributor Covenant ([http://contributor-covenant.org](http://contributor-covenant.org/)) w wersji 2.0, dostępnej pod adresem [http://contributor-covenant.org/version/2/0/code_of_conduct/](http://contributor-covenant.org/version/2/0/code_of_conduct/).


### PR DESCRIPTION
Updating Polish translation.

The CNCF has had a professional translation service provide this version of the code of conduct.

Deploy preview: https://github.com/nate-double-u/cncf-foundation/blob/2024-03-26-NW-code-of-conduct-translation-update-Polish/code-of-conduct-languages/pl.md

Note: I didn't do the translation on this (just providing the markdown), but comments are welcome!
