### PR TITLE
Updating code of conduct translation: Spanish

### DIFF
--- a/code-of-conduct-languages/es.md
+++ b/code-of-conduct-languages/es.md
@@ -1,29 +1,66 @@
-Código de Conducta para la Comunidad de la CNCF v1.0
-----------------------------------------------------
+## Código de Conducta para la Comunidad
 
-### Código de Conducta para los Colaboradores
+Como colaboradores, mantenedores y participantes de la comunidad de la CNCF, y en el interés de promover una comunidad abierta y cordial, nos comprometemos a respetar a todas las personas que colaboren denunciando problemas, publicando solicitudes de función, actualizando documentación, presentando pedidos de validación o parches, asistiendo a conferencias o eventos, o participando en otras actividades de proyectos o de la comunidad.
 
-Como colaboradores y mantenedores de este proyecto, y en el interés de promover una comunidad abierta y cordial, nos comprometemos a respetar a todas las personas que colaboren denunciando problemas, publicando solicitudes de función, actualizando documentación, presentando pedidos de validación o parches, entre otras actividades.
+Estamos comprometidos con hacer de la participación de todos los involucrados en la comunidad de la CNCF una experiencia libre de hostigamiento de cualquier índole, sin importar su edad, tamaño corporal, clase, discapacidad, grupo étnico, nivel de experiencia, estado familiar, género, identidad y expresión de género, estado civil, estado de militar o veterano, nacionalidad, aspecto personal, raza, religión, orientación sexual, situación socioeconómica, tribu ni cualquier otra dimensión de diversidad.
 
-Estamos comprometidos con hacer de la participación de todos los involucrados en este proyecto una experiencia libre de hostigamiento de cualquier índole, sin importar su nivel de experiencia, género, identidad y expresión de género, orientación sexual, discapacidad, aspecto personal, tamaño corporal, raza, grupo étnico, edad, religión ni su nacionalidad.
+## Alcance
 
-Algunos ejemplos de conducta inaceptable imputable a los participantes pueden ser:
+Este código de conducta se aplica:
+* dentro de los espacios relacionados con el proyecto y la comunidad,
+* en otros espacios cuando las palabras o las acciones de un participante individual de la comunidad de la CNCF están dirigidas a o tratan sobre un proyecto de la CNCF, la comunidad de la CNCF u otro participante de la comunidad de la CNCF.
 
--	El uso de palabras o imágenes sesgadas de contenido sexual.
--	Ataques personales
--	Comentarios provocadores, insultantes o despectivos
--	Acoso público o privado
--	Publicar información privada ajena, como pueden ser domicilios particulares o direcciones electrónicas, sin contar con permiso explícito para hacerlo
--	Cualquier otra conducta reñida con la ética o el profesionalismo.
+## Eventos de la CNCF
 
-Los mantenedores de proyectos tienen el derecho y la responsabilidad de eliminar, editar o rechazar los comentarios, consignas, códigos, correcciones colaborativas (del tipo “wiki edits”), ediciones y demás contribuciones que no estuvieren en consonancia con los principios establecidos en el presente Código de Conducta. Al adoptar este Código de Conducta, los mantenedores de proyectos se comprometen a aplicar estos principios de manera justa y uniforme a todos los aspectos que hacen a la gestión de este proyecto. Los mantenedores de proyectos que no cumplan ni hagan cumplir este Código de Conducta podrían quedar desafectados en forma permanente del equipo encargado del proyecto.
+Los eventos de la CNCF que son producidos por la Fundación Linux con personal profesional de eventos se rigen por el [Código de Conducta para Eventos](https://events.linuxfoundation.org/code-of-conduct/) de la Fundación Linux disponible en la página de eventos. Dicho código está diseñado para usarse junto con el Código de Conducta de la CNCF.
 
-Este Código de Conducta se aplica tanto dentro de los espacios relacionados con el proyecto como en espacios públicos y siempre que un individuo esté representando al proyecto o su comunidad.
+## Nuestros estándares
 
-Los casos de comportamiento abusivo, acosador o de cualquier otro modo inaceptable podrán ser denunciados poniéndose en contacto con el [Comité del Código de Conducta de Kubernetes](https://git.k8s.io/community/committee-code-of-conduct) en <conduct@kubernetes.io>. Para otros proyectos, comuníquese con un mantenedor de proyectos de CNCF o con nuestra mediadora, Mishi Choudhary <mishi@linux.com>.
+La Comunidad de la CNCF es abierta, inclusiva y respetuosa. Cada miembro de nuestra comunidad tiene derecho a que se respete su identidad.
 
-Este Código de Conducta está adaptado del Compromiso de Colaboradores (http://contributor-covenant.org), versión 1.2.0, disponible en http://contributor-covenant.org/version/1/2/0/
+Entre otros, los siguientes son ejemplos de comportamiento que contribuye a un ambiente positivo:
+* Demostrar empatía y amabilidad hacia otras personas
+* Ser respetuoso de las diferentes opiniones, puntos de vista y experiencias
+* Hacer críticas constructivas y aceptarlas con dignidad
+* Aceptar la responsabilidad y pedir disculpas a los afectados por nuestros errores, y aprender de la experiencia
+* Centrarse en lo que es mejor no solo para nosotros como individuos, sino para la comunidad en general
+* Usar un lenguaje cordial e inclusivo
 
-### Código de Conducta para la Comunidad de la CNCF
+Entre otros, los siguientes son ejemplos de comportamiento inaceptable:
+* El uso de palabras o imágenes sesgadas de contenido sexual
+* Comentarios provocadores, insultantes o despectivos y ataques personales o políticos
+* Acoso público o privado de cualquier índole
+* Publicar información privada ajena, como pueden ser domicilios particulares o direcciones electrónicas, sin contar con su permiso explícito para hacerlo
+* Violencia, amenazas de violencia o alentar a otros a participar en conductas violentas
+* Acechar o seguir a alguien sin su consentimiento
+* Contacto físico indeseado
+* Atención o insinuaciones sexuales o románticas indeseadas
+* Otra conducta que podría considerarse razonablemente inapropiada en un entorno profesional
 
-Los eventos de la CNCF se rigen por el Código de Conducta de la Fundación Linux disponible en la página de eventos. Dicho código está diseñado para resultar compatible con la política descrita anteriormente, así como también incluye más detalles sobre cómo responder ante la ocurrencia de incidentes.
+Los siguientes comportamientos también están prohibidos:
+* Proporcionar información falsa o engañosa a sabiendas en relación con una investigación del Código de Conducta o manipular una investigación intencionalmente.
+* Tomar represalias contra una persona porque denunció un incidente o proporcionó información sobre un incidente como testigo.
+
+Los mantenedores de proyectos tienen el derecho y la responsabilidad de eliminar, editar o rechazar los comentarios, consignas, códigos, correcciones colaborativas (del tipo “wiki edits”), ediciones y demás contribuciones que no estuvieren en consonancia con los principios establecidos en el presente Código de Conducta. Al adoptar este Código de Conducta, los mantenedores de proyectos se comprometen a aplicar estos principios de manera justa y uniforme a todos los aspectos que hacen a la gestión de un proyecto de la CNCF. Los mantenedores de proyectos que no cumplan ni hagan cumplir este Código de Conducta podrían quedar desafectados en forma temporaria o permanente del equipo encargado del proyecto.
+
+## Denuncias
+
+Para incidentes que ocurran en la comunidad de Kubernetes, comuníquese con el [Comité del Código de Conducta de Kubernetes](https://git.k8s.io/community/committee-code-of-conduct) a través de [conduct@kubernetes.io](mailto:conduct@kubernetes.io). Puede esperar una respuesta dentro de los tres días hábiles.
+
+Para otros proyectos, o para incidentes que sean independientes del proyecto o que afecten a varios proyectos de la CNCF, comuníquese con el [Comité del Código de Conducta de la CNCF](https://www.cncf.io/conduct/committee/) a través de [conduct@cncf.io](mailto:conduct@cncf.io). Alternativamente, puede ponerse en contacto con cualquiera de los miembros individuales del [Comité del Código de Conducta de la CNCF](https://www.cncf.io/conduct/committee/) para hacer su denuncia. Para obtener instrucciones más detalladas sobre cómo hacer una denuncia, incluido cómo hacer una denuncia de forma anónima, consulte nuestros [Procedimientos de Resolución de Incidentes](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md). Puede esperar una respuesta dentro de los tres días hábiles.
+
+Para incidentes que ocurran en el evento de la CNCF producido por la Fundación Linux, escriba a [eventconduct@cncf.io](mailto:eventconduct@cncf.io).
+
+## Exigencia de cumplimiento
+
+Tras la revisión e investigación de un incidente denunciado, el equipo de respuesta del CdC que tenga jurisdicción determinará qué medida es apropiada en función de este Código de Conducta y su documentación relacionada.
+
+Para obtener información sobre qué incidentes del Código de Conducta son manejados por los líderes del proyecto, qué incidentes son manejados por el Comité del Código de Conducta de la CNCF y qué incidentes son manejados por la Fundación Linux (incluido su equipo de eventos), consulte nuestra [Política de Jurisdicción](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md).
+
+## Correcciones
+
+De conformidad con los Estatutos de la CNCF, cualquier cambio sustantivo a este Código de Conducta debe ser aprobado por el Comité de Supervisión Técnica.
+
+## Reconocimientos
+
+Este Código de Conducta está adaptado del Compromiso de Colaboradores ([http://contributor-covenant.org](http://contributor-covenant.org/)), versión 2.0, disponible en [http://contributor-covenant.org/version/2/0/code_of_conduct/](http://contributor-covenant.org/version/2/0/code_of_conduct/)


### PR DESCRIPTION
Updating Spanish translation.

The CNCF has had a professional translation service provide this version of the code of conduct.

Deploy preview: https://github.com/nate-double-u/cncf-foundation/blob/2024-04-09-NW-code-of-conduct-translation-update-Spanish/code-of-conduct-languages/es.md

Note: I didn't do the translation on this (just providing the markdown), but comments are welcome!
