### PR TITLE
Updating code of conduct translation: Turkish

### DIFF
--- a/code-of-conduct-languages/tr.md
+++ b/code-of-conduct-languages/tr.md
@@ -1,57 +1,66 @@
-## CNCF Topluluğu Davranış Kuralları v1.2
+## Topluluk Davranış Kuralları
 
-### Katkıda Bulunanlar için Davranış Kuralları
+CNCF topluluğuna katkı yapan ve topluluğun devamını sağlayan kişiler ve topluluğun katılımcıları olarak, açık ve samimi bir topluluğun gelişimini teşvik etme amacıyla; sorunları raporlayarak, özellik talepleri yayımlayarak, belgeleri güncelleyerek, çekme talepleri veya yamalar göndererek, konferanslara veya etkinliklere katılarak ya da diğer topluluk veya proje faaliyetlerinde bulunarak katılım sağlayan ya da katkıda bulunan herkese saygı duyacağımızı taahhüt ediyoruz.
 
-Bu projeye katkıda bulunanlar ve proje geliştiricileri olarak açık ve misafirperver bir topluluğun gelişimini teşvik etmek için, sorunları bildirerek, özellik talepleri yayınlayarak, belge güncelleyerek, pull request’ler veya yamalar göndererek ve diğer faaliyetler yoluyla katkıda bulunan tüm insanlara saygı duyacağımızı taahhüt ediyoruz.
-
-Deneyim seviyesi, cinsiyet, cinsel kimlik ve ifade, cinsel yönelim, engellilik, kişisel görünüm, vücut ölçüsü, ırk, etnik köken, yaş, din veya milliyetten bağımsız olarak bu projeye katılımı herkes için tacizden arındırılmış bir deneyim haline getirmeye kararlıyız.
+CNCF topluluğuna katılımı yaş, vücut ölçüsü, sosyal sınıf, engellilik durumu, etnik köken, deneyim seviyesi, aile durumu, cinsiyet, cinsiyet kimliği ve ifadesi, medeni durum, askerlik veya gazilik durumu, milliyet, kişisel görünüm, ırk, din, cinsel yönelim, sosyoekonomik durum, kabile mensubiyeti ya da çeşitlilik bağlamında herhangi bir başka boyuttan bağımsız olarak herkes için tacizden arındırılmış bir deneyim haline getirmeye kararlıyız.
 
 ## Kapsam
 
-Bu davranış kuralları, bir kişi projeyi veya topluluğu temsil ettiğinde hem proje alanlarında hem de kamusal alanlarda geçerlidir.
+Bu davranış kuralları şu alanlarda geçerlidir:
+* proje ve topluluk alanları dahilinde,
+* bireysel bir CNCF topluluğu katılımcısının söz veya eylemlerinin bir CNCF projesine, CNCF topluluğuna ya da bir başka CNCF topluluğu katılımcısına yönelik veya bunlar hakkında olduğu diğer alanlarda.
 
-### CNCF Etkinlikleri
+## CNCF Etkinlikleri
 
-CNCF etkinlikleri veya Linux Vakfı tarafından profesyonel etkinlik personeli ile yürütülen, Linux Vakfı tarafından yönetilen etkinlikler [Etkinlik Davranış Kuralları](https://events.linuxfoundation.org/code-of-conduct/) etkinlik sayfasında bulunur. Bu, CNCF Davranış Kuralları ile birlikte kullanılmak üzere tasarlanmıştır.
+Profesyonel etkinlik personeli ile Linux Vakfı tarafından düzenlenen CNCF etkinlikleri, etkinlik sayfasında mevcut olan Linux Vakfı [Etkinlik Davranış Kuralları](https://events.linuxfoundation.org/code-of-conduct/)'na tabidir. Bu, CNCF Davranış Kuralları ile bağlantılı olarak kullanılmak üzere tasarlanmıştır.
 
 ## Standartlarımız
 
-Olumlu bir ortama katkıda bulunan davranış örnekleri şunları içerir:
+CNCF Topluluğu açık, kapsayıcı ve saygıya dayalı bir topluluktur. Topluluğumuzun her bir üyesi, kimliğine saygı gösterilme hakkına sahiptir.
 
-* Diğer insanlara karşı empati ve nezaket göstermek
+Ortamın olumlu bir havaya sahip olmasına katkıda bulunan davranış örnekleri, bunlarla sınırlı olmamak üzere aşağıdakileri içerir:
+* Diğer insanlara empati ve nezaketle yaklaşmak
 * Farklı görüşlere, bakış açılarına ve deneyimlere saygılı olmak
-* Yapıcı geri bildirim vermek ve incelikle kabul etmek
-* Sorumluluğu kabul etmek ve hatalarımızdan etkilenenlerden özür dilemek ve deneyimden öğrenme
+* Yapıcı geri bildirimde bulunmak ve yapıcı geri bildirimi nezaketle kabul etmek
+* Sorumluluğu kabul etmek, hatalarımızdan etkilenenlerden özür dilemek ve deneyimlerden ders çıkarmak
 * Sadece bireyler olarak bizim için değil, tüm toplum için en iyisinin ne olduğuna odaklanmak
+* Samimi ve kapsayıcı bir dil kullanmak
 
-Kabul edilemez davranış örnekleri şunları içerir:
+Kabul edilemez davranış örnekleri, bunlarla sınırlı olmamak üzere aşağıdakileri içerir:
+* Cinselleştirilmiş dil veya imge kullanımı
+* Trolleme, hakaret niteliğinde veya aşağılayıcı yorumlar ve kişisel ya da siyasi saldırılar
+* Herhangi bir biçimde herkese açık veya gizli şekilde tacizde bulunmak
+* Başkalarının fiziksel veya e-posta adresi gibi özel bilgilerini açık izinleri olmadan yayımlamak
+* Şiddet uygulamak, şiddetle tehdit etmek ya da başkalarını şiddet içerikli davranışta bulunmaya teşvik etmek
+* Sanal takip veya onayı olmadan birini takip etmek
+* İstenmeyen fiziksel temas
+* İstenmeyen cinsel ya da romantik ilgi veya yakınlaşma çabası
+* Profesyonel bir ortamda mantıken uygunsuz kabul edilebilecek diğer davranışlar
 
-* Cinselleştirilmiş dil veya imge kullanımı ve her türlü cinsel ilgi veya ilerleme
-* Trolleme, hakaret veya aşağılayıcı yorumlar ve kişisel veya siyasi saldırılar
-* Kamusal veya özel taciz
-* Başkalarının fiziksel veya e-posta adresi gibi özel bilgilerini açık izinleri olmadan yayınlamak
-* Profesyonel bir ortamda makul olarak uygunsuz kabul edilebilecek diğer davranışlar
+Ayrıca aşağıdaki davranışlar da yasaktır:
+* Davranış Kuralları ile ilgili bir soruşturmayla bağlantılı olarak bilerek hatalı ya da yanlış yönlendirici bilgi vermek veya soruşturmayı farklı biçimlerde kasti olarak etkilemeye çalışmak.
+* Tanık olarak bir olayı rapor ettiği ya da olay hakkında bilgi verdiği için bir kişiye karşı misillemede bulunmak.
 
-Proje sahipleri, bu Davranış Kuralları ile uyumlu olmayan yorumları, taahhütleri, kodları, wiki düzenlemelerini, sorunları ve diğer katkıları kaldırma, düzenleme veya reddetme hakkına ve sorumluluğuna sahiptir.
-Proje yürütücüleri, bu Davranış Kurallarını benimseyerek, bu ilkeleri bu projeyi yönetmenin her yönüne adil ve tutarlı bir şekilde uygulamayı taahhüt eder.
-Davranış Kurallarını takip etmeyen veya uygulamayan proje yürütücüleri, proje ekibinden kalıcı olarak çıkarılabilir.
+Proje sorumluları, bu Davranış Kuralları ile uyumlu olmayan yorumları, girişleri, kodları, wiki düzenlemelerini, sorunları ve diğer katkıları kaldırma, düzenleme ya da reddetme hakkına ve sorumluluğuna sahiptir. Proje sorumluları, bu Davranış Kurallarını kabul ettiklerinde bir CNCF projesi yönetmenin her aşamasında söz konusu ilkeleri adil ve tutarlı bir biçimde uygulama taahhüdünde bulunmuş olur. Davranış Kurallarını uygulamayan ya da yürürlüğe koymayan proje sorumluları, proje ekibinden geçici veya kalıcı olarak çıkarılabilir.
 
 ## Raporlama
 
-Kubernetes topluluğunda meydana gelen olaylar için <conduct@kubernetes.io> aracılığıyla [Kubernetes Davranış Kuralları Komitesi](https://git.k8s.io/community/committee-code-of-conduct) ile iletişime geçin. Üç iş günü içinde yanıt bekleyebilirsiniz.
+Kubernetes topluluğunda meydana gelen olaylar için [conduct@kubernetes.io](mailto:conduct@kubernetes.io) adresi üzerinden [Kubernetes Davranış Kuralları Komitesi](https://git.k8s.io/community/committee-code-of-conduct) ile iletişime geçin. Normal şartlarda üç iş günü içinde yanıt alırsınız.
 
-Diğer projeler veya projeden bağımsız olan veya birden fazla CNCF projesini etkileyen olaylar için lütfen conduct@cncf.io aracılığıyla [CNCF Davranış Kuralları Komitesi](https://www.cncf.io/conduct/committee/) ile iletişime geçin. Alternatif olarak, raporunuzu göndermek için [CNCF Davranış Kuralları Komitesinin](https://www.cncf.io/conduct/committee/) herhangi bir üyesiyle iletişime geçebilirsiniz. Bir raporun isimsiz olarak nasıl gönderileceği de dahil olmak üzere bir raporun nasıl gönderileceğine ilişkin daha ayrıntılı talimatlar için lütfen [Olay Çözüm Prosedürlerimize](https://www.cncf.io/conduct/procedures/) bakın. Üç iş günü içinde yanıt bekleyebilirsiniz.
+Diğer projeler veya projeden bağımsız olan ya da birden fazla CNCF projesini etkileyen olaylar için lütfen [conduct@cncf.io](mailto:conduct@cncf.io) adresi üzerinden [CNCF Davranış Kuralları Komitesi](https://www.cncf.io/conduct/committee/) ile iletişime geçin. Alternatif olarak, raporunuzu göndermek için [CNCF Davranış Kuralları Komitesi](https://www.cncf.io/conduct/committee/) üyelerinin herhangi biri ile iletişime geçebilirsiniz. Bir raporun nasıl gönderileceğine ilişkin daha ayrıntılı talimatlar için lütfen [Olay Çözümleme Prosedürlerimize](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md) bakın. Normal şartlarda üç iş günü içinde yanıt alırsınız.
 
-## Yürütme
+Linux Vakfı tarafından düzenlenen bir CNCF etkinliğinde meydana gelen olaylar için lütfen [eventconduct@cncf.io](mailto:eventconduct@cncf.io) ile iletişime geçin.
 
-Kubernetes projesinin [Davranış Kuralları Komitesi](https://github.com/kubernetes/community/tree/master/committee-code-of-conduct), Kubernetes projesi için davranış kuralları konularını uygular.
+## Uygulama
 
-Kendi Davranış Kuralları Komitesi veya diğer Davranış Kuralları olay müdahale görevlileri olmayan tüm projeler ve projeden bağımsız olan veya birden fazla projeyi etkileyen olaylar için [CNCF Davranış Kuralları Komitesi](https://www.cncf.io/conduct/committee/) davranış kuralları konularını zorunlu kılar. Daha fazla bilgi için bizim [Yargı Yetkisi ve Yükseltme Politikamıza](https://www.cncf.io/conduct/jurisdiction/) bakın.
+Rapor edilen bir olayın incelenip soruşturulmasının ardından yargı yetkisine sahip olan CoC müdahale ekibi, bu Davranış Kuralları ve ilgili belgeleri esas alarak hangi eylemin uygun olduğuna karar verecektir.
 
-Her iki kurum da olayları cezalandırmadan çözmeye çalışır, ancak kendi takdirlerine bağlı olarak insanları projeden veya CNCF topluluklarından çıkarabilir.
+Hangi Davranış Kuralları olaylarının proje liderliği tarafından, hangi olayların CNCF Davranış Kuralları Komitesi tarafından ve hangi olayların Linux Vakfı (vakfın etkinlikler ekibi dahil) tarafından ele alındığı hakkında bilgi için [Yargı Yetkisi Politikamıza](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md) bakın.
+
+## Değişiklikler
+
+CNCF Sözleşmesi ile tutarlı olacak şekilde bu Davranış Kuralları'nda yapılacak tüm önemli değişiklikler, Teknik Denetim Komitesi tarafından onaylanmalıdır.
 
 ## Teşekkür
 
-Bu Davranış Kuralları, Katılımcı Sözleşmesi'nden uyarlanmıştır
-(http://contributor-covenant.org), sürüm 2.0 şu adreste mevcuttur:
-http://contributor-covenant.org/version/2/0/code_of_conduct/
+Bu Davranış Kuralları, [http://contributor-covenant.org/version/2/0/code_of_conduct/](http://contributor-covenant.org/version/2/0/code_of_conduct/) adresinde bulunan Katılımcı Sözleşmesi'nin ([http://contributor-covenant.org](http://contributor-covenant.org/)) 2.0 numaralı sürümünden uyarlanmıştır.


### PR DESCRIPTION
Updating Turkish translation.

The CNCF has had a professional translation service provide this version of the code of conduct.

Deploy preview: https://github.com/nate-double-u/cncf-foundation/blob/2024-04-09-NW-code-of-conduct-translation-update-Turkish/code-of-conduct-languages/tr.md

Note: I didn't do the translation on this (just providing the markdown), but comments are welcome!
