### PR TITLE
Updating code of conduct translation: Vietnamese

### DIFF
--- a/code-of-conduct-languages/vi.md
+++ b/code-of-conduct-languages/vi.md
@@ -1,28 +1,66 @@
-## Quy tắc ứng xử cộng đồng CNCF v1.0
+## Quy Tắc Ứng Xử Cộng Đồng
 
-### Quy tắc ứng xử của những người đóng góp
+Là những người đóng góp, duy trì và tham gia cộng đồng CNCF và để thúc đẩy một cộng đồng cởi mở và thân thiện, chúng tôi cam kết tôn trọng tất cả những người có đóng góp hoặc tham gia bằng cách gửi báo cáo những vấn đề, đăng yêu cầu tính năng, cập nhật tài liệu, gửi các yêu cầu kéo (pull request) hoặc bản vá, tham dự các hội thảo hoặc sự kiện hoặc tham gia vào các hoạt động khác của cộng đồng hoặc dự án.
 
-Là những người đóng góp và duy trì dự án này, và vì việc thúc đẩy một cộng đồng mở và sẵn sàng chào đón, chúng tôi cam kết tôn trọng tất cả những người đóng góp thông qua việc báo cáo những vấn đề, yêu cầu tính năng, cập nhật tài liệu, tạo các Pull Requests hoặc bản vá và những hoạt động khác.
+Chúng tôi cam kết tất cả những người tham gia vào cộng đồng CNCF sẽ không bị quấy rối, bất kể tuổi tác, kích thước cơ thể, địa vị xã hội, tình trạng khuyết tật, sắc tộc, mức độ kinh nghiệm, tình trạng gia đình, giới tính, bản dạng và biểu hiện giới tính, tình trạng hôn nhân, tư cách quân nhân hoặc cựu chiến binh, quốc tịch, ngoại hình cá nhân, chủng tộc, tôn giáo, khuynh hướng tình dục, tình trạng kinh tế xã hội, bộ lạc hoặc bất kỳ đặc điểm đa dạng nào khác.
 
-Chúng tôi cam kết khi tham gia vào dự án này, mọi người sẽ không bị quấy rối, bất kể mức độ kinh nghiệm, giới tính, khuynh hướng tình dục, khuyết tật, ngoại hình, kích thước cơ thể, chủng tộc, tuổi tác, tôn giáo hoặc Quốc tịch.
+## Phạm Vi
 
-Các ví dụ về hành vi không được chấp nhận của người tham gia, gồm:
+Quy tắc ứng xử này được áp dụng:
+* trong các không gian dự án và cộng đồng,
+* trong các không gian khác khi một người tham gia cộng đồng CNCF có lời nói hoặc hành động hướng tới hoặc về một dự án CNCF, cộng đồng CNCF hoặc một người tham gia cộng đồng CNCF khác.
 
-* Sử dụng ngôn ngữ hoặc hình ảnh đồi trụy
-* Công kích cá nhân
-* Bình luận lăng mạ/xúc phạm
-* Quấy rối công khai hoặc riêng tư
-* Công bố thông tin cá nhân của người khác như địa chỉ chỗ ở hoặc địa chỉ điện tử khi không có sự cho phép rõ ràng
-* Hành vi phi đạo đức hoặc cư xử không chuyên nghiệp khác
+## Các Sự Kiện CNCF
 
-Người duy trì dự án có quyền và trách nhiệm xóa, chỉnh sửa hoặc từ chối các bình luận, commits, mã nguồn, chỉnh sửa wiki, các issues, và các đóng góp khác mà không phù hợp với quy tắc ứng xử này. Khi đưa vào bộ quy tắc ứng xử này, những người duy trì dự án cam kết áp dụng một cách công bằng và nhất quán các nguyên tắc này cho mọi khía cạnh của việc quản lý dự án. Những người duy trì dự án không tuân theo hoặc thực thi Quy tắc ứng xử có thể bị xóa tên vinh viễn khỏi nhóm dự án.
+Các sự kiện CNCF do Linux Foundation tổ chức với đội ngũ nhân viên sự kiện chuyên nghiệp được kiểm soát bởi [Quy Tắc Ứng Xử của Sự Kiện](https://events.linuxfoundation.org/code-of-conduct/) của Linux Foundation có sẵn trên trang web của sự kiện. Quy tắc này được thiết kế để sử dụng cùng với Quy Tắc Ứng Xử CNCF.
 
-Quy tắc ứng xử này áp dụng cả trong không gian dự án và không gian công cộng khi một cá nhân đại diện cho dự án hoặc cộng đồng của dự án.
+## Tiêu Chuẩn của Chúng Tôi
 
-Các trường hợp lạm dụng, quấy rối hoặc những hành vi không thể chấp nhận được trong Kubernetes có thể báo cáo bằng cách liên hệ với [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) qua <conduct@kubernetes.io>. Đối với những dự án khác, vui lòng liên hệ với người duy trì dự án CNCF hoặc người hòa giải của chúng tôi, Mishi Choudhary <mishi@linux.com>.
+Cộng Đồng CNCF là một cộng đồng cởi mở, hòa nhập và tôn trọng. Mọi thành viên trong cộng đồng chúng tôi đều có quyền nhận được sự tôn trọng đối với bản dạng của mình.
 
-Quy tắc ứng xử này được điều chỉnh từ quy ước người đóng góp (http://contributor-covenant.org), phiên bản 1.2.0, tại http://contributor-covenant.org/version/1/2/0/
+Ví dụ về hành vi góp phần tạo nên môi trường tích cực bao gồm nhưng không giới hạn ở:
+* Thể hiện sự đồng cảm và lòng tốt đối với người khác
+* Tôn trọng những ý kiến, quan điểm và kinh nghiệm khác biệt
+* Đưa ra và chấp nhận những phản hồi mang tính xây dựng một cách lịch thiệp
+* Nhận trách nhiệm và xin lỗi những người bị ảnh hưởng bởi lỗi lầm của chính chúng ta và rút kinh nghiệm
+* Tập trung vào những gì tốt nhất không chỉ cho cá nhân chúng ta mà còn cho cả cộng đồng
+* Sử dụng ngôn ngữ có tính chào đón và hòa nhập
 
-### Quy tắc ứng xử của các sự kiện CNCF
+Ví dụ về hành vi không được chấp nhận bao gồm nhưng không giới hạn ở:
+* Việc sử dụng ngôn ngữ hoặc hình ảnh gợi dục
+* Những bình luận có tính khiêu khích, xúc phạm hoặc sỉ nhục, cũng như tấn công về mặt cá nhân hoặc chính trị
+* Quấy rối tại nơi công cộng hoặc riêng tư dưới mọi hình thức
+* Công khai thông tin cá nhân của người khác, chẳng hạn như địa chỉ chỗ ở hoặc địa chỉ email của họ mà không có sự cho phép rõ ràng của họ
+* Bạo lực, đe dọa bạo lực hoặc khuyến khích người khác thực hiện hành vi bạo lực
+* Rình rập hoặc theo dõi ai đó mà không có sự đồng ý của họ
+* Tiếp xúc cơ thể không được chào đón
+* Sự chú ý hoặc hành vi tán tỉnh với ý đồ gợi dục hoặc lãng mạn không được chào đón
+* Hành vi khác có thể được coi là không phù hợp trong môi trường chuyên nghiệp
 
-Các sự kiện CNCF được điều chỉnh bởi [Quy tắc ứng xử](https://events.linuxfoundation.org/code-of-conduct/) của Linux Foundation ở trên trang sự kiện. Nó được thiết kế để tương thích với chính sách trên và cũng bao gồm nhiều chi tiết hơn về việc ứng phó với các sự cố.
+Các hành vi sau đây cũng bị cấm:
+* Cung cấp thông tin cố ý sai lệch hoặc gây hiểu lầm liên quan đến cuộc điều tra về Quy Tắc Ứng Xử hoặc cố ý làm thay đổi cuộc điều tra.
+* Trả thù một người vì họ đã báo cáo sự cố hoặc là nhân chứng cung cấp thông tin về sự cố.
+
+Những người duy trì dự án có quyền và trách nhiệm xóa, chỉnh sửa hoặc từ chối các bình luận, commit, dòng mã, chỉnh sửa wiki, vấn đề và các đóng góp khác không phù hợp với Quy Tắc Ứng Xử này. Bằng việc áp dụng Quy Tắc Ứng Xử này, những người duy trì dự án cam kết áp dụng một cách công bằng và nhất quán những nguyên tắc này trong mọi vấn đề quản lý dự án CNCF. Những người duy trì dự án không tuân theo hoặc thực thi Quy Tắc Ứng Xử có thể bị xóa tên tạm thời hoặc vĩnh viễn khỏi nhóm dự án.
+
+## Báo Cáo
+
+Đối với các sự cố xảy ra trong cộng đồng Kubernetes, hãy gửi email cho [Ủy Ban Quy Tắc Ứng Xử Kubernetes](https://git.k8s.io/community/committee-code-of-conduct) tại địa chỉ [conduct@kubernetes.io](mailto:conduct@kubernetes.io). Quý vị có thể nhận được phản hồi trong vòng ba ngày làm việc.
+
+Đối với các dự án khác hoặc các sự cố không liên quan đến dự án hoặc ảnh hưởng đến nhiều dự án CNCF, vui lòng gửi email cho [Ủy Ban Quy Tắc Ứng Xử CNCF](https://www.cncf.io/conduct/committee/) tại địa chỉ [conduct@cncf.io](mailto:conduct@cncf.io). Ngoài ra, quý vị có thể liên hệ với bất kỳ thành viên cá nhân nào của [Ủy Ban Quy Tắc Ứng Xử CNCF](https://www.cncf.io/conduct/committee/) để gửi báo cáo của quý vị. Để biết chi tiết hơn về cách thức gửi báo cáo, bao gồm cách gửi báo cáo ẩn danh, vui lòng xem [Quy Trình Giải Quyết Sự Cố](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md). Quý vị có thể nhận được phản hồi trong vòng ba ngày làm việc.
+
+Đối với các sự cố xảy ra tại sự kiện CNCF do Linux Foundation tổ chức, vui lòng liên hệ [eventconduct@cncf.io](mailto:eventconduct@cncf.io).
+
+## Thực Thi
+
+Sau khi xem xét và điều tra sự cố được báo cáo, nhóm ứng phó CoC có thẩm quyền sẽ xác định hành động nào là phù hợp dựa trên Quy Tắc Ứng Xử này và tài liệu liên quan.
+
+Để biết thông tin về sự cố nào về Quy Tắc Ứng Xử do nhóm lãnh đạo dự án xử lý, sự cố nào do Ủy Ban Quy Tắc Ứng Xử CNCF xử lý cũng như các sự cố do Linux Foundation xử lý (bao gồm cả nhóm sự kiện của tổ chức này), hãy xem [Chính Sách về Thẩm Quyền](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md).
+
+## Sửa Đổi
+
+Theo quy định trong Điều Lệ CNCF, mọi thay đổi quan trọng đối với Quy Tắc Ứng Xử này đều phải được Ủy Ban Giám Sát Kỹ Thuật phê duyệt.
+
+## Xác Nhận
+
+Quy tắc ứng xử này được điều chỉnh từ Quy ước người đóng góp ([http://contributor-covenant.org](http://contributor-covenant.org/)), bản 2.0 có sẵn tại [http://contributor-covenant.org/version/2/0/code_of_conduct/](http://contributor-covenant.org/version/2/0/code_of_conduct/)


### PR DESCRIPTION
Updating Vietnamese translation.

The CNCF has had a professional translation service provide this version of the code of conduct.

Deploy preview: https://github.com/nate-double-u/cncf-foundation/blob/2024-04-09-NW-code-of-conduct-translation-update-Vietnamese/code-of-conduct-languages/vi.md

Note: I didn't do the translation on this (just providing the markdown), but comments are welcome!
