### PR TITLE
add new maintainer for Kubean

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1543,3 +1543,13 @@ Sandbox,Krkn,Naga Ravi Chaitanya Elluri,Red Hat,chaitanyaenr,https://github.com/
 ,,Tullio Sebastiani,Red Hat,tsebastiani,
 ,,Pradeep Surisetty,Red Hat,psuriset,
 ,,Christian Hernandez,Akuity,christianh814,
+Sandbox,Kubean,Erik Jiang,Daocloud,ErikJiang,https://github.com/kubean-io/kubean/blob/main/MAINTAINERS.md
+,,Guangli Bao,DaoCloud,tukwila,
+,,Nathan Jiang,Independent,hangscer8,
+,,Lihai Tu,DaoCloud,tu1h,
+,,Michael Yao,DaoCloud,windsonsea,
+,,Xiao Zhang,DaoCloud,wawa0210,
+,,Peter Pan,DaoCloud,panpan0000,
+,,Kai Yan,DaoCloud,yankay,
+,,Shaolong Qin,DaoCloud,KubeKyrie,
+,,Panyintian Fu,DaoCloud,FloatXD,


### PR DESCRIPTION
Kubean is recently proved to be a sandbox project, this PR adds its maintainers

context:
https://github.com/cncf/toc/issues/1301
https://github.com/cncf/sandbox/issues/49