### PR TITLE
Update code-of-conduct.md to resolve CNCF out of compliance activity.

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -29,7 +29,7 @@ an open and welcoming community, we pledge to respect all people who participate
 through reporting issues, posting feature requests, updating documentation,
 submitting pull requests or patches, attending conferences or events, or engaging in other community or project activities.
 
-We are committed to making participation in the CNCF community a harassment-free experience for everyone, regardless of age, body size, caste, disability, ethnicity, level of experience, family status, gender, gender identity and expression, marital status, military or veteran status, nationality, personal appearance, race, religion, sexual orientation, socioeconomic status, tribe, or any other dimension of diversity.
+We are committed to making participation in the CNCF community a harassment-free experience for everyone, regardless of age, body size, caste, disability, ethnicity, level of experience, family status, marital status, military or veteran status, nationality, personal appearance, race, religion, sexual orientation, socioeconomic status, tribe, or any other dimension of diversity.
 
 ## Scope
 


### PR DESCRIPTION
# Problem

The [CNCF KubeCon NA 2024 event](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) has been organized in a state [actively discriminating against and deputizing civilians](https://ut-sao-special-prod.web.app/sex_basis_complaint.html) to weaponize government against an at risk minority with non-trivial representation in the larger cloud native community.

This continued pattern of non-compliance with CNCF CoC should be corrected via behavioral change, or policy change to eliminate risks to the CNCF of being perceived as being above accountability to their own policies.

# Resolution

Correct the Code of Conduct to correctly reflect CNCF behavior and resolve the out-of-compliance actions of the CNCF with regards to their promotion of community events in discriminatory hostile venues. By updating the CoC, adherence to the CoC can be resolved and this change commit can be referenced as the official determination of the CNCF if future complaints of gender discrimination are raised.