### PR TITLE
Update longhorn maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -464,6 +464,8 @@ Incubating,Longhorn,Sheng Yang,SUSE,yasker,https://github.com/longhorn/longhorn/
 ,,David Ko,SUSE,innobead,
 ,,Derek Su,SUSE,derekbit,
 ,,Phan Le,SUSE,PhanLe1010,
+,,Chinya Huang,SUSE,c3y1huang,
+,,Eric Weber,SUSE,ejweber,
 Incubating,CubeFS,Haifeng Liu ,_,bladehliu,https://github.com/cubefs/cubefs/blob/master/MAINTAINERS.md
 ,,Xiaochun HE,OPPO,xiaochunhe,
 ,,Liang Chang,OPPO,leonrayang,


### PR DESCRIPTION
Add new maintainers (Chinya, Eric) to Longhorn. They are already added to the maintainer list of the Longhorn repo at https://github.com/longhorn/longhorn/blob/master/MAINTAINERS#L9-L10 