### PR TITLE
Update the Strimzi level to Incubating

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -442,12 +442,12 @@ Incubating,In-Toto,Justin Cappos,New York University,JustinCappos,https://github
 ,,Santiago Torres,Purdue University,SantiagoTorres,
 ,,Sebastien Awwad,Conda,awwad,
 ,,Aditya Sirish A Yelgundhalli,NYU,adityasaky,
-Sandbox,Strimzi,Jakub Scholz,Red Hat,scholzj,https://github.com/strimzi/strimzi-kafka-operator/blob/master/MAINTAINERS
+Incubating,Strimzi,Jakub Scholz,Red Hat,scholzj,https://github.com/strimzi/strimzi-kafka-operator/blob/master/MAINTAINERS
 ,,Paolo Patierno,Red Hat,ppatierno,
 ,,Tom Bentley,Red Hat,tombentley,
 ,,Jakub Stejskal,Red Hat,Frawless ,
 ,,Sam Hawker,IBM,samuel-hawker,
-,,Stanislav Knot,Red Hat,sknot-rh,
+,,Stanislav Knot,CN Group,sknot-rh,
 ,,Paul Mellor,Red Hat,PaulRMellor,
 ,,Lukáš Král,Red Hat,im-konge,
 ,,Maroš Orsák,Red Hat,see-quick,


### PR DESCRIPTION
This PR updates the level of the Strimzi project in the project maintainers list from Sandbox to Incubating as Strimzi moved to Incubating earlier this year. It also updates the company affiliation for Stanislav Knot - one of the Strimzi maintainers.