### PR TITLE
feat(falco): update status and maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -307,7 +307,7 @@ Graduated,CloudEvents,Doug Davis,Microsoft,duglin,https://github.com/cloudevents
 ,,Mark Peek,VMware,markpeek,
 ,,Ken Owens,Mastercard,kenowens12,
 ,,Klaus Deissner,SAP,deissnerk,
-Incubating,Falco,Andrea Terzolo,Sysdig,andreagit97,https://github.com/falcosecurity/evolution/blob/main/MAINTAINERS.md#core-maintainers
+Graduated,Falco,Andrea Terzolo,Sysdig,andreagit97,https://github.com/falcosecurity/evolution/blob/main/MAINTAINERS.md#core-maintainers
 ,,Carlos Tadeu Panato Junior,Chainguard,cpanato,
 ,,Federico Di Pierro,Sysdig,fededp,
 ,,Grzegorz Nosek,Sysdig,gnosek,

--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -321,6 +321,7 @@ Graduated,Falco,Andrea Terzolo,Sysdig,andreagit97,https://github.com/falcosecuri
 ,,Michele Zuccala,Sysdig,zuc,
 ,,Thomas Labarussias,Sysdig,issif,
 ,,Aldo Lacuku,Sysdig,alacuku,
+,,Samuel Gaist,Idiap Research Institute,sgaist,
 Graduated,SPIFFE,Andres Vega,VMware,anvega,https://github.com/spiffe/spiffe/blob/main/CODEOWNERS
 ,,Evan Gilman,VMware,evan2645,
 ,,Andrew Jessup,HPE,ajessup,


### PR DESCRIPTION
This PR does two things:

- Update the status of the Falco project to match the current situation (Incubating -> Graduated)
- Update the maintainers list to add myself

The graduation announcement can be found [here](https://www.cncf.io/announcements/2024/02/29/cloud-native-computing-foundation-announces-falco-graduation/).