### PR TITLE
Add Erik Godding Boye as a cert-manager maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -746,6 +746,7 @@ Incubating,cert-manager,James Munnelly,Apple,munnerz,https://github.com/jetstack
 ,,Maël Valais,Venafi,maelvls,
 ,,Tim Ramlot,Venafi,inteon,
 ,,Adam Talbot,Venafi,ThatsMrTalbot,
+,,Erik Godding Boye,Zenior AS,erikgb,
 Sandbox,OpenKruise,Fei Guo,Alibaba,Fei-Guo,https://github.com/openkruise/kruise/blob/master/MAINTAINERS.md
 ,,Siyu Wang,Alibaba,FillZpp,
 ,,Zhen Zhang,Alibaba,furykerry,


### PR DESCRIPTION
As described here: https://github.com/cert-manager/community/pull/32#issuecomment-2285854108
Erik is a newly accepted cert-manager maintainer and should be in the `project-maintainers.csv` file.

@erikgb FYI