### PR TITLE
Add OSCAL-COMPASS maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1598,3 +1598,10 @@ Sandbox,bpfman,Dave Tucker,Red Hat,dave-tucker,https://github.com/bpfman/bpfman/
 ,,Andrew Stoycos,Red Hat,astoycos,
 ,,Andre Fredette,Red Hat,anfredette,
 ,,Billy McFall,Red Hat,Billy99,
+Sandbox,OSCAL-COMPASS,Anca Sailer,IBM,ancatri,https://github.com/oscal-compass/community/blob/main/MAINTAINERS.md
+,,Lou DeGenaro,IBM,degenaro,
+,,Jay Flowers,Red Hat,jflowers,
+,,Jennifer Power,Red Hat,jpower432,
+,,Manjiree Gadgil,IBM,mrgadgil,
+,,Yuji Watanabe,IBM,yuji-watanabe-jp,
+,,Vikas Agarwal,IBM,vikas-agarwal76,


### PR DESCRIPTION
Add OSCAL-COMPASS maintainers to `project-maintainer.csv`. 

Related to https://github.com/cncf/toc/issues/1371