### PR TITLE
Removing Martin as a Helm maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -248,7 +248,6 @@ Graduated,Helm,Matt Butcher,Microsoft,technosophos,https://github.com/helm/commu
 ,,Josh Dolitsky,Blood Orange,jdolitsky,
 ,,Scott Rigby,Independent,scottrigby,
 ,,Karen Chu,Microsoft,karenhchu,
-,,Martin Hickey,IBM,hickeyma,
 Graduated,Rook,Satoru Takeuchi,Cybozu,satoru-takeuchi,https://github.com/rook/rook/blob/master/OWNERS.md
 ,,Jared Watts,Upbound,jbw976,
 ,,Sebastien Han,Red Hat,leseb,


### PR DESCRIPTION
Martin has stepped down from the role. You can see it at https://lists.cncf.io/g/cncf-helm/topic/stepping_down_as_helm/107404058