### PR TITLE
Update Kubernetes steering members for 2024 election

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1,11 +1,11 @@
 ﻿,Project,Maintainer Name,Company,Github Name,OWNERS/MAINTAINERS
-Graduated,Kubernetes,Bob Killen,Google,mrbobbytables,https://git.k8s.io/steering#members
-,,Stephen Augustus,Cisco,justaugustus,
+Graduated,Kubernetes,Antonio Ojea,Google,aojea,https://git.k8s.io/steering#members
 ,,Benjamin Elder,Google,BenTheElder,
-,,Nabarun Pal,VMware,palnabarun,
-,,Maciej Szulik,Red Hat,soltysh,
+,,Maciej Szulik,Defense Unicorns,soltysh,
 ,,Paco Xu 徐俊杰,DaoCloud,pacoxu,
 ,,Patrick Ohly,Intel,pohly,
+,,Sascha Grunert,Red Hat,saschagrunert,
+,,Stephen Augustus,Cisco,justaugustus,
 ,Kubernetes: SIG Contributor Experience (non-voting),Josh Berkus,Red Hat,jberkus,https://git.k8s.io/community/sig-contributor-experience#leadership
 ,,Christoph Blecker,Red Hat,cblecker,
 ,,Kaslin Fields,Google,kaslin,


### PR DESCRIPTION
### Results from https://kubernetes.io/blog/2024/10/02/steering-committee-results-2024/

Congratulations to the elected committee members whose two year terms begin immediately (listed in alphabetical order by GitHub handle):
- Antonio Ojea ([@aojea](https://github.com/aojea)), Google
- Benjamin Elder ([@BenTheElder](https://github.com/bentheelder)), Google
- Sascha Grunert ([@saschagrunert](https://github.com/saschagrunert)), Red Hat

They join continuing members:
- Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), Cisco
- Paco Xu 徐俊杰 ([@pacoxu](https://github.com/pacoxu)), DaoCloud
- Patrick Ohly ([@pohly](https://github.com/pohly)), Intel
- Maciej Szulik ([@soltysh](https://github.com/soltysh)), Defense Unicorns
- Benjamin Elder is a returning Steering Committee Member.

Thanks to the Emeritus Steering Committee Members. Your service is appreciated by the community:

- Bob Killen ([@mrbobbytables](https://github.com/mrbobbytables))
- Nabarun Pal ([@palnabarun](https://github.com/palnabarun))


xref https://github.com/kubernetes/steering/issues/286