### PR TITLE
chore(project-maintainers): Reconciles wasmCloud project maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -968,10 +968,12 @@ Sandbox,ORAS (OCI Registry as Storage),Andrew Block,Red Hat,sabre1041,https://gi
 ,,Sajay Antony,Microsoft,sajayantony,
 ,,Shiwei Zhang,Microsoft,shizhMSFT,
 ,,Terry Howe,AWS,TerryHowe,
-Sandbox,wasmCloud,Brooks Townsend,Capital One,brooksmtownsend,https://github.com/wasmCloud/wasmCloud/blob/main/MAINTAINERS.md
+Sandbox,wasmCloud,Brooks Townsend,Cosmonic,brooksmtownsend,https://github.com/wasmCloud/wasmCloud/blob/main/MAINTAINERS.md
 ,,Liam Randall,Cosmonic,liamrandall,
-,,Kevin Hoffman,wasmCloud,autodidaddict,
 ,,Taylor Thomas,Cosmonic,thomastaylor312,
+,,Bailey Hayes,Cosmonic,ricochet,
+,,Jordan Rash,Synadia,jordan-rash,
+,,Colin Murphy,Adobe,cdmurph32,
 Sandbox,Akri,Kate Goldenring,Fermyon,kate-goldenring,https://github.com/project-akri/akri/blob/main/CODEOWNERS
 ,,Brian Fjeldstad,Microsoft,bfjelds,
 ,,Roaa Sakr,Microsoft,romoh,


### PR DESCRIPTION
Most of the maintainers were unaware this file existed! We've fixed this in our onboarding documents, but this PR updates the list of wasmCloud org maintainers to match the current org maintainers for wasmCloud.

This can be double checked in the linked MAINTAINERS.md file for verification