### PR TITLE
Remove two former Cilium maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -875,8 +875,6 @@ Graduated,Cilium,Aditi Ghag,Isovalent,aditighag,https://github.com/cilium/cilium
 ,,Tobias Klauser,Isovalent,tklauser,
 ,,Tom Hadlaw,Isovalent,tommyp1ckles,
 ,,Vlad Ungureanu,Palantir,ungureanuvladvictor,
-,,Weilong Cui,Google,Weil0ng,
-,,Yongkun Gui,Google,anfernee,
 ,,Yutaro Hayakawa,Isovalent,YutaroHayakawa,
 Sandbox,Vineyard,Tao He,Alibaba,sighingnow,https://github.com/alibaba/v6d/blob/main/MAINTAINERS.md
 ,,Xiaojian Luo,Alibaba,luoxiaojian,


### PR DESCRIPTION
Yongkun and Weilong stepped down from their role as Cilium maintainers (called Committers in the Cilium project). See
https://github.com/cilium/cilium/pull/35359 for the upstream change.