### PR TITLE
Update project-maintainers.csv

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -455,7 +455,6 @@ Incubating,Longhorn,Sheng Yang,SUSE,yasker,https://github.com/longhorn/longhorn/
 ,,Derek Su,SUSE,derekbit,
 ,,Phan Le,SUSE,PhanLe1010,
 ,,Chinya Huang,SUSE,c3y1huang,
-,,Eric Weber,SUSE,ejweber,
 Incubating,CubeFS,Haifeng Liu ,_,bladehliu,https://github.com/cubefs/cubefs/blob/master/MAINTAINERS.md
 ,,Xiaochun HE,OPPO,xiaochunhe,
 ,,Liang Chang,OPPO,leonrayang,


### PR DESCRIPTION
chore: remove inactive member from longhorn

The upstream maintainer list has been updated accordingly. https://github.com/longhorn/longhorn/pull/9750.