### PR TITLE
Update OpenTelemetry Governance Committee members

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -386,10 +386,10 @@ Sandbox,Network Service Mesh,Ed Warnicke,Cisco,edwarnicke,https://github.com/net
 ,,Andrey Sobolev,Xored,haiodo,
 Incubating,OpenTelemetry (Governance Committee),Alolita Sharma,Apple,alolita,https://github.com/open-telemetry/community/blob/master/community-members.md#governance-committee
 ,,Austin Parker,Honeycomb,austinlparker,
-,,Daniel Dyla,Dynatrace,dyladan,
 ,,Daniel Gomez Blanco,Skyscanner,danielgblanco,
 ,,Juraci Paixão Kröhling,Grafana Labs,jpkrohling,
 ,,Morgan James McLean,Splunk,mtwo,
+,,Pablo Baeyens Fernandez,Datadog,mx-psi,
 ,,Severin Neumann,Cisco,svrnm,
 ,,Ted Young,Lightstep,tedsuo,
 ,,Trask Stalnaker,Microsoft,trask,


### PR DESCRIPTION
As of the 2024 election results published in https://vote.heliosvoting.org/helios/e/otel-gc-2024 to match the list in https://github.com/open-telemetry/community/blob/main/community-members.md#governance-committee