### PR TITLE
Remove `agilgur5` from Argo maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -515,7 +515,6 @@ Graduated,Argo, Saravanan Balasubramanian,Intuit,sarabala1979,https://github.com
 ,,Blake Pettersson,Akuity,blakepettersson,
 ,,Alan Clucas,Pipekit,Joibel,
 ,,Isitha Subasinghe,Pipekit,isubasinghe,
-,,Anton Gilgur,Independent,agilgur5,
 Sandbox,CNI-Genie,Zefeng (Kevin) Wang,Huawei ,kevin-wangzefeng,https://github.com/cni-genie/CNI-Genie/blob/master/MAINTAINERS
 ,,Sushantha Kumar,Huawei ,sushanthakumar,
 ,,Jun Du,Huawei ,m1093782566,


### PR DESCRIPTION
Removing myself, `agilgur5`, from Argo maintainers as I resigned

Source:
- Argoproj: https://github.com/argoproj/argoproj/pull/336
- Argo Workflows: https://github.com/argoproj/argo-workflows/pull/13837

Effectively the inverse of #800