### PR TITLE
feat: update kyverno maintainers list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -766,10 +766,7 @@ Sandbox,Pravega,Flavio Junqueira,Pravega,fpj,https://github.com/pravega/.github/
 ,,Raul Gracia,Dell,RaulGracia,
 Incubating,Kyverno,Jim Bugwadia,Nirmata,JimBugwadia,https://github.com/kyverno/kyverno/blob/main/MAINTAINERS.md
 ,,Shuting Zhao,Nirmata,realshuting,
-,,Chip Zoller,Stackwatch,chipzoller,
-,,Marcel Muller,Giant Swarm GmbH,MarcelMue,
-,,Trey Dockendorf,treydock,Ohio Supercomputer Center,
-,,Frank Jogeleit,Lovoo GmbH,fjogeleit,
+,,Frank Jogeleit,Nirmata,fjogeleit,
 ,,Charles-Edouard Brétéché,Nirmata,eddycharly,
 ,,Vishal Choudhary,Nirmata,vishal-chdhry,
 ,,Mariam Fahmy,Nirmata,MariamFahmy98,


### PR DESCRIPTION
Update maintainers csv to remove emeritus maintainers
List: https://github.com/kyverno/community/blob/main/MAINTAINERS.md