### PR TITLE
Add kuma project maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -598,6 +598,7 @@ Sandbox,Kuma,Jakub Dyszkiewicz,Kong,jakubdyszkiewicz,https://github.com/kumahq/k
 ,,James Peach ,Kong,jpeach,
 ,,Mike Beaumont ,Kong,michaelbeaumont,
 ,,Paul Parkanzky ,Kong,parkanzky,
+,,Icarus Wu ,Kong,Icarus9913,
 Sandbox,Parsec,Adam Parco,Docker,adamparco,https://github.com/parallaxsecond/parsec/blob/master/MAINTAINERS.toml
 ,,Sabree Blackmon,Docker,heavypackets,
 ,,Hugues de Valon,ARM,hug-dev,


### PR DESCRIPTION
Hi, 

Please review and accept the enclosed updates to the list of Kuma maintainers.
The reference tracking information is here: https://github.com/kumahq/kuma/pull/12091

Thanks

