### PR TITLE
Add Kate Stanley as a new Strimzi project maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -443,6 +443,7 @@ Incubating,Strimzi,Jakub Scholz,Red Hat,scholzj,https://github.com/strimzi/strim
 ,,Paul Mellor,Red Hat,PaulRMellor,
 ,,Lukáš Král,Red Hat,im-konge,
 ,,Maroš Orsák,Red Hat,see-quick,
+,,Kate Stanley,Red Hat,katheris,
 Incubating,KubeVirt,David Vossel,Red Hat,davidvossel,https://github.com/kubevirt/community/blob/master/MAINTAINERS.md
 ,,Vladik Romanovsky,Red Hat,vladikr,
 ,,Roman Mohr,Google,rmohr,


### PR DESCRIPTION
This PR adds Kate Stanley (katheris) as a new maintainer of the Strimzi project into the project-maintainers.csv file.