### PR TITLE
Update Envoy Gateway maintainer status

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -72,8 +72,7 @@ Graduated,Envoy,Matt Klein,bitdrift,mattklein123,https://github.com/envoyproxy/e
 ,,Arko Dasgupta,Tetrate,arkodg,
 ,,Jianpeng He,Tetrate,zirain,
 ,,Huabing Zhao,Tetrate,zhaohuabing,
-,,Xunzhuo Liu,Tencent,Xunzhuo,
-,,Alice Wasko,Ambassador Labs,AliceProxy,
+,,Xiaohan Hu,Huawei,shawnh2,
 ,,Guy Daich,SAP,guydc,
 ,,,,,
 Graduated,CoreDNS,Chris O'Haver,Infoblox,chrisohaver,https://github.com/coredns/coredns/blob/master/CODEOWNERS


### PR DESCRIPTION
- remove duplicate name of `Xunzhuo Liu` (disappeared in L71)
- remove `Alice Wasko` from Envoy Gateway maintainers
- add `Xiaohan Hu` as a Envoy Gateway maintainer

cc @arkodg