### PR TITLE
Add checklist to remind of additional maintainer management tasks.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+### Pre-submission checklist
+
+_If you're adding a new maintainer to the CSV file, please confirm each of these actions has been completed:_
+
+- [ ] You've also sent a PR with updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
+- [ ] The maintainer has updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
+- [ ] You've sent an email to <cncf-maintainer-changes@cncf.io> for access to Service Desk and the mailing lists for the email address.


### PR DESCRIPTION
There are several tasks that should be done when a maintainer is added, updated, or removed.

Eventually this process will be automated and be self-serve, but for now we need to make sure each step is followed to ensure consistency.