### PR TITLE
Proposed Code of Conduct Updates for January 2025

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -71,7 +71,7 @@ Examples of unacceptable behavior include but are not limited to:
 * Unwelcome physical contact
 * Unwelcome sexual or romantic attention or advances
 * Using CNCF projects or community spaces for political campaigning or promotion of political causes 
-  that are unrelated to the advancement of cloud native technology. To clarify, this policy does not restrict individuals from expressing personal views through their attire.
+  that are unrelated to the advancement of cloud native technology. To clarify, this policy does not restrict individuals' personal attire, including attire that expresses personal beliefs or aspects of identity.
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 


### PR DESCRIPTION
The CNCF Code of Conduct Committee is proposing a change to the Code of Conduct to prevent use of CNCF projects and CNCF community spaces for political campaigning or promotion of political causes that are unrelated to tech. 

As a community that exists for the purpose of promoting cloud native technology, unrelated political causes are outside our scope. In the past, use of CNCF community spaces to promote unrelated political causes has proven to be distracting and divisive, even when numerous community members feel passionate about the cause. There are more appropriate forums outside of CNCF for promotion of political causes.

