### PR TITLE
Add Kubernetes new SIG ContribEx CoChair to non voting maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -12,6 +12,7 @@ Graduated,Kubernetes,Antonio Ojea,Google,aojea,https://git.k8s.io/steering#membe
 ,,Madhav Jivrajani,VMware,MadhavJivrajani,
 ,,Nikhita Raghunath,VMware,nikhita,
 ,,Priyanka Saggu,SUSE,Priyankasaggu11929,
+,,Mario Fahlandt,Kubermatic,mfahlandt,
 ,Kubernetes: SIG K8s Infra (non-voting),Arnaud Meukam,Independent,ameukam,https://git.k8s.io/community/sig-k8s-infra#leadership
 ,,Aaron Crickenberger,Google,spiffxp,
 ,,Davanum Srinivas,AWS,dims,


### PR DESCRIPTION
Based on this onboarding Issue https://github.com/kubernetes/community/issues/8304 add mfahlandt to the maintainers.csv for Kubernetes ContribEx

### Pre-submission checklist

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [ *] The maintainer has updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ *] You've sent an email to <cncf-maintainer-changes@cncf.io> for access to Service Desk and the mailing lists for the email address.
- [ ] Optional: You've also sent a PR with updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
