### PR TITLE
Update Vitess maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -119,7 +119,6 @@ Graduated,Jaeger,Yuri Shkuro,Meta,yurishkuro,https://github.com/jaegertracing/ja
 ,,Mahad Zaryab,Bloomberg,mahadzaryab1,
 Graduated,Vitess,Deepthi Sigireddi,PlanetScale,deepthi,https://github.com/vitessio/vitess/blob/master/MAINTAINERS.md
 ,,Andres Taylor,PlanetScale,systay,
-,,Andrew Mason,Independent,amason,
 ,,Arthur Schreiber,Microsoft,arthurschreiber,
 ,,Derek Perkins,Nozzle,derekperkins,
 ,,Dirkjan Bussink,PlanetScale,dbussink,


### PR DESCRIPTION
Removing Andrew Mason from Vitess. See https://github.com/vitessio/vitess/pull/17745

### Pre-submission checklist

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [ ] The maintainer has updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
