### PR TITLE
Action to validate changes to maintainers.

### DIFF
--- a/.github/workflows/validate-csv.yml
+++ b/.github/workflows/validate-csv.yml
@@ -2,7 +2,10 @@
 # Source: https://github.com/krook/csv-lint
 # Test:   https://github.com/krook/csv-lint-test
 
-on: [pull_request]
+on: 
+  pull_request:
+    paths:
+      - 'project-maintainers.csv'
 
 jobs:
   verify-cvs-validation:

--- a/.github/workflows/validate-csv.yml
+++ b/.github/workflows/validate-csv.yml
@@ -1,0 +1,15 @@
+# Used to validate changes to the project-maintainers.csv file
+# Source: https://github.com/krook/csv-lint
+# Test:   https://github.com/krook/csv-lint-test
+
+on: [pull_request]
+
+jobs:
+  verify-cvs-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate CSV
+        uses: krook/csv-lint@main
+        env:
+          CSV_FILE: "file.csv"

--- a/.github/workflows/validate-csv.yml
+++ b/.github/workflows/validate-csv.yml
@@ -12,4 +12,4 @@ jobs:
       - name: Validate CSV
         uses: krook/csv-lint@main
         env:
-          CSV_FILE: "file.csv"
+          CSV_FILE: "project-maintainers.csv"


### PR DESCRIPTION
- [x] Add a GitHub Action to validate changes to the maintainers file by linting the CSV
- [x] Still need to pattern match to run only on changes to the `project-maintainers.csv` rather than all pull requests