### PR TITLE
Add MasonM to Argo maintainers and fix branch name 

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -511,7 +511,7 @@ Incubating,Volcano,Klaus Ma,Huawei,k82cn,https://github.com/volcano-sh/volcano/b
 ,,Zhonghu Xu,Huawei,hzxuzhonghu,
 ,,Thor-wl,Huawei,Thor-wl,
 ,,William-wang,Huawei,william-wang,
-Graduated,Argo, Saravanan Balasubramanian,Intuit,sarabala1979,https://github.com/argoproj/argoproj/blob/master/MAINTAINERS.md
+Graduated,Argo, Saravanan Balasubramanian,Intuit,sarabala1979,https://github.com/argoproj/argoproj/blob/main/MAINTAINERS.md
 ,,Chetan Banavikalmutt,Red Hat,chetan-rns,
 ,,Simon Behar,AirBnB,simster7,
 ,,Xianlu Bird,Alibaba Cloud,xianlubird,
@@ -549,6 +549,7 @@ Graduated,Argo, Saravanan Balasubramanian,Intuit,sarabala1979,https://github.com
 ,,Alan Clucas,Pipekit,Joibel,
 ,,Isitha Subasinghe,Pipekit,isubasinghe,
 ,,Shuangkun Tian,Alibaba Cloud,shuangkun,
+,,Mason Malone,Adobe,MasonM,
 Sandbox,CNI-Genie,Zefeng (Kevin) Wang,Huawei ,kevin-wangzefeng,https://github.com/cni-genie/CNI-Genie/blob/master/MAINTAINERS
 ,,Sushantha Kumar,Huawei ,sushanthakumar,
 ,,Jun Du,Huawei ,m1093782566,


### PR DESCRIPTION
I was recently promoted to be a maintainer for Argo Workflows: https://github.com/argoproj/argoproj/blob/6f39106cf1b27de0efe7e50668aaeb2f26d469d7/MAINTAINERS.md?plain=1#

Also, I fixed the branch name for https://github.com/argoproj/argoproj/blob/main/MAINTAINERS.md, since `master` was renamed to `main`.

Here's my LFX profile: https://openprofile.dev/profile/masonmalone

### Pre-submission checklist

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [X] The maintainer has updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [X] You've sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
