### PR TITLE
Updating devfile maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1118,6 +1118,7 @@ Sandbox,Devfile,Andreas Resios,AWS,resios, https://github.com/devfile/api/blob/m
 ,,Angel Misevski,Red Hat,amisevsk,
 ,,Elson Yuen,Red Hat,elsony,
 ,,Ida Olsen,AWS,miaida,
+,,Mario Loriedo,Red Hat,l0rd,
 ,,Stevan Le Meur,Red Hat,slemeur,
 ,,Tomas Kral,Red Hat,kadel,
 Incubating,Knative,Ali Ok,Red Hat,aliok, https://github.com/knative/community/blob/main/OWNERS_ALIASES


### PR DESCRIPTION
👋 I am a maintainer of the [Devfile Sanbox project](https://devfile.io) since day one (c.f. the [maintainers file](https://github.com/devfile/api/blob/main/MAINTAINERS.md)) but for some reason I am not included in the `project-maintainers.csv` file.

### Pre-submission checklist

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [x] The maintainer has updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
