### PR TITLE
Adding Divya to Longhorn maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -496,6 +496,7 @@ Incubating,Longhorn,Sheng Yang,SUSE,yasker,https://github.com/longhorn/longhorn/
 ,,Shuo Wu,SUSE,shuo-wu,
 ,,David Ko,SUSE,innobead,
 ,,Derek Su,SUSE,derekbit,
+,,Divya Mohan,SUSE,divya-mohan0209,
 ,,Phan Le,SUSE,PhanLe1010,
 ,,Chinya Huang,SUSE,c3y1huang,
 Incubating,CubeFS,Haifeng Liu ,_,bladehliu,https://github.com/cubefs/cubefs/blob/master/MAINTAINERS.md


### PR DESCRIPTION
As the [community manager/maintainer for Longhorn](https://github.com/longhorn/longhorn/blob/master/MAINTAINERS#L10), synching my affiliation with the CNCF Maintainers file.

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [x] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).

