### PR TITLE
Update Keycloak Project Maintainer affiliation for thomasdarimont

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1458,7 +1458,7 @@ Incubating,Keycloak,Stian Thorgersen,Red Hat,stianst,https://github.com/keycloak
 ,,Sebastian Schuster,Bosch,sschu,
 ,,Stan Silvert,Red Hat,ssilvert,
 ,,Takashi Norimatsu,Hitachi,tnorimat,
-,,Thomas Darimont,codecentric AG,thomasdarimont,
+,keycloak,Thomas Darimont,Identity Tailor GmbH,thomasdarimont,https://github.com/keycloak/keycloak/blob/main/MAINTAINERS.md
 ,,Václav Muzikář,Red Hat,vmuzikar,
 Sandbox,Kepler,Huamin Chen,Red Hat,rootfs,https://github.com/sustainable-computing-io/kepler/blob/main/MAINTAINERS.md
 ,,Ji Chen,IBM,jichenjc,


### PR DESCRIPTION
As a [maintainer for Keycloak](https://github.com/keycloak/keycloak/blob/main/MAINTAINERS.md?plain=1#L12), synching my affiliation with the CNCF Maintainers file.

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [x] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
