### PR TITLE
Add Dipti Pai to Flux maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -466,6 +466,7 @@ Graduated,Flux,Stefan Prodan,ControlPlane,stefanprodan,https://github.com/fluxcd
 ,,Kingdon Barrett, Independent,kingdonb,
 ,,Scott Rigby,Replicated,scottrigby,
 ,,Tamao Nakahara, Independent,mewzherder,
+,,Dipti Pai, Microsoft,dipti-pai,
 Incubating,In-Toto,Justin Cappos,New York University,JustinCappos,https://github.com/in-toto/in-toto/blob/develop/MAINTAINERS.txt
 ,,Lukas Puehringer,NYU,lukpueh,
 ,,Marina Moore,NYU,mnm678,


### PR DESCRIPTION
### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [x] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
