### PR TITLE
Removing Vasiliy and Alice as KubeVirt maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -483,12 +483,10 @@ Incubating,Strimzi,Jakub Scholz,Red Hat,scholzj,https://github.com/strimzi/strim
 Incubating,KubeVirt,David Vossel,Red Hat,davidvossel,https://github.com/kubevirt/community/blob/master/MAINTAINERS.md
 ,,Vladik Romanovsky,Red Hat,vladikr,
 ,,Roman Mohr,Google,rmohr,
-,,Vasiliy Ulyanov,SuSE,vasiliy-ul,
 ,,Stu Gott,Red Hat,stu-gott,
 ,,Fabian Deutsch,Red Hat,fabiand,
 ,,Ryan Hallisey,Nvidia,rthallisey,
 ,,Andrew Burden,Red Hat,aburdenthehand,
-,,Alice Frosi,Red Hat,alicefr,
 ,,Ľuboslav Pivarč,Red Hat,xpivarc,
 Incubating,Longhorn,Sheng Yang,SUSE,yasker,https://github.com/longhorn/longhorn/blob/master/MAINTAINERS
 ,,Shuo Wu,SUSE,shuo-wu,


### PR DESCRIPTION
Updating KubeVirt maintainers list as two of our maintainers recently stepped down:
Vasiliy: https://github.com/kubevirt/community/pull/396
Alice: https://github.com/kubevirt/community/pull/406