### PR TITLE
update(project-maintainers.csv): add ekoops as Falco maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -418,6 +418,7 @@ Graduated,Falco,Andrea Terzolo,Sysdig,andreagit97,https://github.com/falcosecuri
 ,,Lorenzo Susini,Sysdig,loresuso,
 ,,Luca Guerra,Sysdig,lucaguerra,
 ,,Mark Stemm,Sysdig,mstemm,
+,,Leonardo Di Giovanna,Sysdig,ekoops,
 ,,Massimiliano Giovagnoli,Clastix,maxgio92,
 ,,Mauro Ezequiel Moltrasio,RedHat,molter73,
 ,,Melissa Kilby,Apple,incertum,


### PR DESCRIPTION
### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [x] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).

I recently became a Falco maintainer and I'm now adding myself to project-maintainers.csv