### PR TITLE
Update Vitess maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -228,7 +228,6 @@ Graduated,Vitess,Deepthi Sigireddi,PlanetScale,deepthi,https://github.com/vitess
 ,,Rohit Nayak,PlanetScale,rohit-nayak-ps,
 ,,Shlomi Noach,PlanetScale,shlomi-noach,
 ,,Tim Vaillancourt,Slack (Salesforce),timvaillancourt,
-,,Vicent Marti,PlanetScale,vmg,
 Incubating,gRPC,Abhishek Kumar,Google,a11r,https://github.com/grpc/grpc/blob/master/MAINTAINERS.md
 ,,Alexander Polcyn,Google,apolcyn,
 ,,Arjun Roy,Google,arjunroy,


### PR DESCRIPTION
Removing vmg who is stepping down.
Ref: https://github.com/vitessio/vitess/pull/18388

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [ ] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
