### PR TITLE
Update project-maintainers.csv (Keycloak)

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1465,7 +1465,6 @@ Incubating,Keycloak,Stian Thorgersen,Red Hat,stianst,https://github.com/keycloak
 ,,Alexander Schwartz,Red Hat,ahus1,
 ,,Bruno Oliveira da Silva,Red Hat,abstractj,
 ,,Marek Posolda,Red Hat,mposolda,
-,,Michal Hajas,Red Hat,mhajas,
 ,,Pedro Igor,Red Hat,pedroigor,
 ,,Sebastian Schuster,Bosch,sschu,
 ,,Stan Silvert,Red Hat,ssilvert,


### PR DESCRIPTION
Michael Hajas has stepped down as a maintainer for the Keycloak project. See https://github.com/keycloak/keycloak/pull/40800

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [ ] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
