### PR TITLE
Add new Flatcar maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1737,6 +1737,9 @@ Incubating,Flatcar Container Linux,Thilo Fromm,Microsoft,t-lo,https://github.com
 ,,Sayan Chowdhury,Microsoft,sayanchowdhury,
 ,,Adrian Vladu,Cloudbase Solutions,ader1990,
 ,,Gabriel Samfira,Cloudbase Solutions,gabriel-samfira,
+,,Jan Bronicki, Microsoft, John15321,
+,,Daniel Zaťovič, Microsoft, danzatt,
+,,Ervin Rácz, Microsoft, ervcz,
 Sandbox,Shipwright,Enrique Encalada,IBM,qu1queee,https://github.com/shipwright-io/community/blob/main/MAINTAINERS.md
 ,,Sascha Schwarze,IBM,SaschaSchwarze0,
 ,,Adam Kaplan,Red Hat,adambkaplan,

--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1738,7 +1738,6 @@ Incubating,Flatcar Container Linux,Thilo Fromm,Microsoft,t-lo,https://github.com
 ,,Adrian Vladu,Cloudbase Solutions,ader1990,
 ,,Gabriel Samfira,Cloudbase Solutions,gabriel-samfira,
 ,,Jan Bronicki, Microsoft, John15321,
-,,Daniel Zaťovič, Microsoft, danzatt,
 ,,Ervin Rácz, Microsoft, ervcz,
 Sandbox,Shipwright,Enrique Encalada,IBM,qu1queee,https://github.com/shipwright-io/community/blob/main/MAINTAINERS.md
 ,,Sascha Schwarze,IBM,SaschaSchwarze0,


### PR DESCRIPTION
This pull request updates the `project-maintainers.csv` file to add new maintainers for the "Incubating, Flatcar Container Linux" project.

### Changes to maintainers:
* Added Jan Bronicki (`John15321`), Daniel Zaťovič (`danzatt`), and Ervin Rácz (`ervcz`) as maintainers from Microsoft.

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [ ] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).