### PR TITLE
Update project-maintainers.csv to add new maintainer for Drasi

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1791,6 +1791,7 @@ Sandbox,Drasi,Allen Jones,Microsoft,agentofreality,https://github.com/drasi-proj
 ,,Aman Singh,Microsoft,amansinghoriginal,
 ,,Daniel Gerlag,Microsoft,danielgerlag,
 ,,Ruokun Niu,Microsoft,ruokun-niu,
+,,Mike Azure, ,ama2369,
 Sandbox,Kmesh,Zefeng Wang,Huawei,kevin-wangzefeng,https://github.com/kmesh-net/kmesh/blob/main/MAINTAINERS.md
 ,,Changye Wu,Huawei,nlgwcy,
 ,,Zhonghu Xu,Huawei,hzxuzhonghu,


### PR DESCRIPTION
Added Mike Azure as a maintainer for Drasi

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [ ] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
