### PR TITLE
Add Simon Schrottner <aepfli> to the maintainers of open-feature

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1242,6 +1242,7 @@ Incubating,OpenFeature,Alex Jones,AWS,AlexsJones,https://openfeature.dev/communi
 ,,Thomas Poignant,Adevinta,thomaspoignant,
 ,,Todd Baert,Dynatrace,toddbaert,
 ,,Weyert de Boer,FNZ,weyert,
+,,Simon Schrottner,Dynatrace,aepfli,
 Sandbox,OpenCost,Ajay Tripathy,IBM,AjayTripathy,https://github.com/kubecost/opencost/blob/develop/MAINTAINERS.md
 ,,Matt Bolt,IBM,mbolt35,
 ,,Alex Meijer,IBM,ameijer,


### PR DESCRIPTION
I want to add myself as an official maintainer of OpenFeature:
- the org config: https://github.com/open-feature/community/blob/7a248734bf23893b84c0c9c123a332ba65589f1e/config/open-feature/org.yaml#L179-L181
- the promotion pr: https://github.com/open-feature/community/pull/438
- the official maintainer team in the org: https://github.com/orgs/open-feature/teams/maintainers

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [x] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
