### PR TITLE
Add tarilabs to Kubeflow Maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1588,6 +1588,7 @@ Incubating,Kubeflow,Aldo Culquicondor,Google,alculquicondor,https://github.com/k
 ,,Josh Bottum,Independent,jbottum,
 ,,Kimonas Sotirchos,Canonical,kimwnasptd,
 ,,Mathew Wicks,Aranui Solutions,thesuperzapper,
+,,Matteo Mortari,Red Hat,tarilabs,
 ,,Prashant Sharma,IBM,scrapcodes,
 ,,Ricardo Martinelli de Oliveira,Red Hat,rimolive,
 ,,Rong Ou,NVIDIA,rongou,


### PR DESCRIPTION
### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [x] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
yes, here: https://openprofile.dev/profile/mmortari
- [x] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
yes, done.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
will do.

@andreyvelich @franciscojavierarceo @terrytangyuan as discussed in today's Kubeflow meeting; thank you.