### PR TITLE
ci: fix typo in Job name

### DIFF
--- a/.github/workflows/validate-csv.yml
+++ b/.github/workflows/validate-csv.yml
@@ -8,7 +8,7 @@ on:
       - 'project-maintainers.csv'
 
 jobs:
-  verify-cvs-validation:
+  verify-csv-validation:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
today (before this PR):

<img width="727" height="124" alt="Screenshot 2025-08-12 at 22 29 23" src="https://github.com/user-attachments/assets/ed7af85e-fb2a-488a-a494-a8a1f04b7f01" />

leads to the following typo in ci/GHA display name

with this PR:

fix typo s/cvs/csv/