### PR TITLE
Removing David Vossel (dvossel) as KubeVirt maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -558,8 +558,7 @@ Incubating,Strimzi,Jakub Scholz,Red Hat,scholzj,https://github.com/strimzi/strim
 ,,Lukáš Král,Red Hat,im-konge,
 ,,Maroš Orsák,Red Hat,see-quick,
 ,,Kate Stanley,Red Hat,katheris,
-Incubating,KubeVirt,David Vossel,Red Hat,davidvossel,https://github.com/kubevirt/community/blob/master/MAINTAINERS.md
-,,Vladik Romanovsky,Red Hat,vladikr,
+Incubating,KubeVirt,Vladik Romanovsky,Red Hat,vladikr,https://github.com/kubevirt/community/blob/master/MAINTAINERS.md
 ,,Roman Mohr,Google,rmohr,
 ,,Stu Gott,Red Hat,stu-gott,
 ,,Fabian Deutsch,Red Hat,fabiand,


### PR DESCRIPTION
David recently stepped away from the KubeVirt project. 
Matching PR from KubeVirt maintainer list: https://github.com/kubevirt/community/pull/413

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [ ] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
