### PR TITLE
Add chewong and zhuangqh to KAITO maintainer list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1775,6 +1775,8 @@ Sandbox,Kanister,Pavan Navarathna,Veeam Software,pavannd1,https://github.com/kan
 ,,Mark Lavi,Veeam Software,mlavi,
 Sandbox,KAITO,Fei Guo,Microsoft,Fei-Guo,https://github.com/kaito-project/kaito/blob/main/MAINTAINERS.md
 ,,Sachi Desai,Microsoft,sdesai345,
+,,Ernest Wong,Microsoft,chewong,
+,,Jerry Zhuang,Microsoft,zhuangqh,
 Sandbox,Sermant,Lai Li,Huawei,lilai23,https://github.com/sermant-io/Sermant/blob/develop/MAINTAINERS.md
 ,,Haopeng Zhang,Huawei,hanbingleixue,
 ,,Yuyi Peng,Huawei,provenceee,


### PR DESCRIPTION
### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

KAITO CODEOWNERS: https://github.com/kaito-project/kaito/blob/main/CODEOWNERS

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [x] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [x] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
