### PR TITLE
code-of-conduct.md: bump the version to 1.4

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,4 +1,4 @@
-## CNCF Community Code of Conduct v1.3
+## CNCF Community Code of Conduct v1.4
 
 Other languages available:
 - [Arabic/العربية](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/ar.md)


### PR DESCRIPTION
No content is changed in this commit.

The version was bumped up to 1.3 in fa32fb0 (2023-06-09) and was never updated since then, despite the non-trivial amount of the changes.

Fix #1109