### PR TITLE
Add project usage URL column for license exception requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/license-exception-request.yaml
+++ b/.github/ISSUE_TEMPLATE/license-exception-request.yaml
@@ -79,7 +79,7 @@ body:
         
         ## :computer: Component details
         
-        Please fill in the table below, with one row for each unique component for which a license exception is requested. In the "Project Usage URL", please include a link to one or more URLs showing the CNCF project source code or other artifact where the component and its license are located. In the "Purpose" column, please briefly (1-2 sentences) describe the functionality of the component and the reason why the Project is using it.
+        Please fill in the table below, with one row for each unique component for which a license exception is requested. In the "Project Usage URL" column, please include one or more URLs showing the CNCF project source code or other artifact where the component and its license are located or used. In the "Purpose" column, please briefly (1-2 sentences) describe the functionality of the component and the reason why the Project is using it.
 
   - type: textarea
     id: component_details


### PR DESCRIPTION
In order to improve efficiency for reviews by the Legal Committee / Governing Board, this change adds a column to the license exception request template, to have the submitters include a link to an example of where the requested component and its license are actually located in the CNCF project's source code or other artifacts.

Signed-off-by: Steve Winslow <steve@swinslow.net>