### PR TITLE
Add Gerald Combs (geraldcombs) as a Falco maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -430,6 +430,7 @@ Graduated,Falco,Andrea Terzolo,Sysdig,andreagit97,https://github.com/falcosecuri
 ,,Thomas Labarussias,Sysdig,issif,
 ,,Aldo Lacuku,Sysdig,alacuku,
 ,,Samuel Gaist,Idiap Research Institute,sgaist,
+,,Gerald Combs,Wireshark Foundation,geraldcombs,
 Graduated,SPIFFE,Andres Vega,VMware,anvega,https://github.com/spiffe/spiffe/blob/main/CODEOWNERS
 ,,Evan Gilman,VMware,evan2645,
 ,,Andrew Jessup,HPE,ajessup,


### PR DESCRIPTION
I'm an approver for falcosecurity/libs:
  https://github.com/falcosecurity/libs/blob/master/OWNERS
  https://github.com/falcosecurity/libs/pull/2592

I'm also listed in the Falco maintainers list at:
  https://github.com/falcosecurity/evolution/blob/main/people/affiliations.json

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [x] You've provided a link to documentation where the project has approved the maintainer change.
- [x] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
