### PR TITLE
Update affiliation for svrnm in OTel Maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -513,7 +513,7 @@ Incubating,OpenTelemetry (Governance Committee),Alolita Sharma,Apple,alolita,htt
 ,,Juraci Paixão Kröhling,OllyGarden,jpkrohling,
 ,,Morgan James McLean,Splunk,mtwo,
 ,,Pablo Baeyens Fernandez,Datadog,mx-psi,
-,,Severin Neumann,Cisco,svrnm,
+,,Severin Neumann,Causely,svrnm,
 ,,Ted Young,Lightstep,tedsuo,
 ,,Trask Stalnaker,Microsoft,trask,
 ,OpenTelemetry (Technical Committee excluding GC members),Armin Ruech,Dynatrace,arminru,https://github.com/open-telemetry/community/blob/master/community-members.md#technical-committee
@@ -1990,6 +1990,7 @@ Sandbox,Stacker,Ramkumar Chinchani,Cisco Systems,rchincha,https://github.com/pro
 ,,Serge Hallyn,Cisco Systems,hallyn,
 ,,Petu Constantin Eusebiu,Cisco Systems,peusebiu,
 ,,Tycho Andersen,Netflix,tych0,
+
 
 
 


### PR DESCRIPTION
Updating my affiliation from Cisco -> Causely

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [ ] You've provided a link to documentation where the project has approved the maintainer change.
- [x] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [x] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
