### PR TITLE
chore(bootc): Update bootc maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1518,6 +1518,7 @@ Sandbox,bootc,Colin Walters,Red Hat,cgwalters,https://github.com/bootc-dev/bootc
 ,,Xiaofeng Wang,Red Hat,henrywang,
 ,,Gursewak Mangat,Red Hat,gursewak1997,
 ,,Joseph Marrero,Red Hat,jmarrero,
+,,Laura Santamaria,Red Hat,nimbinatus
 Sandbox,Eraser,Sertac Ozercan,Microsoft,sozercan,https://github.com/eraser-dev/eraser/blob/main/MAINTAINERS.md
 ,,Ashna Mehrotra,Microsoft,ashnamehrotra,
 ,,Peter Engelbert,Microsoft,pmengelbert,
@@ -1985,6 +1986,7 @@ Sandbox,Stacker,Ramkumar Chinchani,Cisco Systems,rchincha,https://github.com/pro
 ,,Serge Hallyn,Cisco Systems,hallyn,
 ,,Petu Constantin Eusebiu,Cisco Systems,peusebiu,
 ,,Tycho Andersen,Netflix,tych0,
+
 
 
 


### PR DESCRIPTION
Per https://github.com/bootc-dev/bootc/pull/1538, updating the maintainer list for bootc.

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [x] You've provided a link to documentation where the project has approved the maintainer change.
    - https://github.com/bootc-dev/bootc/pull/1538
- [x] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
