### PR TITLE
update logging-operator maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1576,9 +1576,13 @@ Incubating,Kubeflow,Aldo Culquicondor,Google,alculquicondor,https://github.com/k
 ,,Yuan Tang,Red Hat,terrytangyuan,
 ,,Yuki Iwai,CyberAgent,tenzen-y,
 Sandbox,Logging Operator,Ferenc Hernádi,Axoflow,ahma,https://github.com/kube-logging/.github/blob/main/MAINTAINERS.md
-,,Márk Sági-Kazár,OpenMeter,sagikazarmark,
+,,Márk Sági-Kazár,-,sagikazarmark,
 ,,Péter Wilcsinszky,Axoflow,pepov,
 ,,Sándor Guba,Axoflow,tarokkk,
+,,Bence Csáti,Axoflow,csatib02,
+,,Szilárd Parrag,Axoflow,overorion,
+,,Attila Szakács,Axoflow,alltilla,
+,,Róbert Fekete,Axoflow,fekete-robert,
 Sandbox,k8sgpt-ai,Alex Jones,AWS,AlexsJones,https://raw.githubusercontent.com/k8sgpt-ai/community/main/MAINTAINERS.md
 ,,Thomas Schuetz,WhizUs,thschue,
 Sandbox,KubeStellar,Andy Anderson,IBM,clubanderson,https://github.com/kubestellar/kubestellar/blob/main/OWNERS


### PR DESCRIPTION
- [X] You've provided a link to documentation where the project has approved the maintainer change.

	- https://github.com/kube-logging/logging-operator/pull/2107

- [X] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [X] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
