### PR TITLE
Add kserve maintainers to the project maintainers list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1976,16 +1976,19 @@ Sandbox,Stacker,Ramkumar Chinchani,Cisco Systems,rchincha,https://github.com/pro
 ,,Tycho Andersen,Netflix,tych0,
 Incubating,KServe,Dan Sun,Bloomberg,yuzisun,https://github.com/kserve/kserve/blob/master/OWNERS
 ,,Yuan Tang,Red Hat,terrytangyuan,
-,,Lize Cai,SAP,lizzzcai,
 ,,Jooho Lee,Red Hat,Jooho,
+,,Filippe Spolti,Red Hat,spolti,
+,,Jin Dong,Bloomberg,greenmoon55,
+,,Edgar Hernández,Red Hat,israel-hdez,
+,,Curtis Maddalozzo,Bloomberg,cmaddalozzo,
+,,Lize Cai,SAP,lizzzcai,
 ,,Sivanantham Chinnaiyan,Idea2IT,sivanantha321,
+,,Andrews Arokiam,Idea2IT,andyi2it,
 ,,Johnu George,Nutanix,johnugeorge,
 ,,Gavrish Prabhu,Nutanix,gavrissh,
-,,Jin Dong,Bloomberg,greenmoon55,
-,,Curtis Maddalozzo,Bloomberg,cmaddalozzo,
-,,Filippe Spolti,Red Hat,spolti,
-,,Edgar Hernández,Red Hat,israel-hdez,
-,,Andrews Arokiam,Idea2IT,andyi2it,
+,,Datta Nimmaturi,Nutanix,Datta0,
 ,,Rachit Chauhan,Intuit,rachitchauhan43,
+
+
 
 

--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1975,16 +1975,17 @@ Sandbox,Stacker,Ramkumar Chinchani,Cisco Systems,rchincha,https://github.com/pro
 ,,Petu Constantin Eusebiu,Cisco Systems,peusebiu,
 ,,Tycho Andersen,Netflix,tych0,
 Incubating,KServe,Dan Sun,Bloomberg,yuzisun,https://github.com/kserve/kserve/blob/master/OWNERS
-,,Yuan Tang,Red Hat,terrytangyuan
-,,Lize Cai,SAP,lizzzcai
-,,Jooho Lee,Red Hat,Jooho
-,,Sivanantham Chinnaiyan,Idea2IT,sivanantha321
-,,Johnu George,Nutanix,johnugeorge
-,,Gavrish Prabhu,Nutanix,gavrissh
-,,Jin Dong,Bloomberg,greenmoon55
-,,Curtis Maddalozzo,Bloomberg,cmaddalozzo
-,,Filippe Spolti,Red Hat,spolti
-,,Edgar Hernández,Red Hat,israel-hdez
-,,Andrews Arokiam,Idea2IT,andyi2it
-,,Rachit Chauhan,Intuit,rachitchauhan43
+,,Yuan Tang,Red Hat,terrytangyuan,
+,,Lize Cai,SAP,lizzzcai,
+,,Jooho Lee,Red Hat,Jooho,
+,,Sivanantham Chinnaiyan,Idea2IT,sivanantha321,
+,,Johnu George,Nutanix,johnugeorge,
+,,Gavrish Prabhu,Nutanix,gavrissh,
+,,Jin Dong,Bloomberg,greenmoon55,
+,,Curtis Maddalozzo,Bloomberg,cmaddalozzo,
+,,Filippe Spolti,Red Hat,spolti,
+,,Edgar Hernández,Red Hat,israel-hdez,
+,,Andrews Arokiam,Idea2IT,andyi2it,
+,,Rachit Chauhan,Intuit,rachitchauhan43,
+
 

--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1978,8 +1978,8 @@ Incubating,KServe,Dan Sun,Bloomberg,yuzisun,https://github.com/kserve/kserve/blo
 ,,Yuan Tang,Red Hat,terrytangyuan,
 ,,Jooho Lee,Red Hat,Jooho,
 ,,Filippe Spolti,Red Hat,spolti,
-,,Jin Dong,Bloomberg,greenmoon55,
 ,,Edgar Hernández,Red Hat,israel-hdez,
+,,Jin Dong,Bloomberg,greenmoon55,
 ,,Curtis Maddalozzo,Bloomberg,cmaddalozzo,
 ,,Lize Cai,SAP,lizzzcai,
 ,,Sivanantham Chinnaiyan,Idea2IT,sivanantha321,
@@ -1988,6 +1988,7 @@ Incubating,KServe,Dan Sun,Bloomberg,yuzisun,https://github.com/kserve/kserve/blo
 ,,Gavrish Prabhu,Nutanix,gavrissh,
 ,,Datta Nimmaturi,Nutanix,Datta0,
 ,,Rachit Chauhan,Intuit,rachitchauhan43,
+
 
 
 

--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1974,10 +1974,17 @@ Sandbox,Stacker,Ramkumar Chinchani,Cisco Systems,rchincha,https://github.com/pro
 ,,Serge Hallyn,Cisco Systems,hallyn,
 ,,Petu Constantin Eusebiu,Cisco Systems,peusebiu,
 ,,Tycho Andersen,Netflix,tych0,
-
-
-
-
-
-
+Incubating,KServe,Dan Sun,Bloomberg,yuzisun,https://github.com/kserve/kserve/blob/master/OWNERS
+,,Yuan Tang,Red Hat,terrytangyuan
+,,Lize Cai,SAP,lizzzcai
+,,Jooho Lee,Red Hat,Jooho
+,,Sivanantham Chinnaiyan,Idea2IT,sivanantha321
+,,Johnu George,Nutanix,johnugeorge
+,,Gavrish Prabhu,Nutanix,gavrissh
+,,Jin Dong,Bloomberg,greenmoon55
+,,Curtis Maddalozzo,Bloomberg,cmaddalozzo
+,,Filippe Spolti,Red Hat,spolti
+,,Edgar Hernández,Red Hat,israel-hdez
+,,Andrews Arokiam,Idea2IT,andyi2it
+,,Rachit Chauhan,Intuit,rachitchauhan43
 


### PR DESCRIPTION
### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)
Add [kserve maintainers](https://github.com/kserve/kserve/blob/master/OWNERS) to CNCF project maintainers list as part of the onboarding https://github.com/cncf/toc/issues/1905.

- [X] You've provided a link to documentation where the project has approved the maintainer change.
- [X] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [X] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
