### PR TITLE
Update project-maintainers.csv

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1893,7 +1893,7 @@ Sandbox,OpenTofu,Christian Mesh,Spacelift.io,cam72cam,https://github.com/opentof
 ,,Martin atkins,Spacelift.io,apparentlymart,
 ,,Andrei Ciobanu,Env0,yottta,
 ,,Ilia Gogotchuri,Env0,Gogotchuri,
-,,Diógenes Fernandes,Gruntworks,diofeher,
+,,Diógenes Fernandes,Gruntwork,diofeher,
 Sandbox,KitOps,Gorkem Ercan,Jozu,gorkem,https://github.com/kitops-ml/kitops/blob/main/MAINTAINERS.md
 ,,Angel Misevski,Jozu,amisevsk,
 ,,Brad Micklea,Jozu,bmicklea,
@@ -1972,6 +1972,7 @@ Sandbox,Stacker,Ramkumar Chinchani,Cisco Systems,rchincha,https://github.com/pro
 ,,Serge Hallyn,Cisco Systems,hallyn,
 ,,Petu Constantin Eusebiu,Cisco Systems,peusebiu,
 ,,Tycho Andersen,Netflix,tych0,
+
 
 
 


### PR DESCRIPTION
There is a typo in Gruntwork's name: https://github.com/gruntwork-io

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [ ] You've provided a link to documentation where the project has approved the maintainer change.
- [ ] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
