### PR TITLE
doc: adding core maintainers for new oauth2-proxy sandbox project

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -2071,6 +2071,6 @@ Incubating,KServe,Dan Sun,Bloomberg,yuzisun,https://github.com/kserve/kserve/blo
 ,,Gavrish Prabhu,Nutanix,gavrissh,
 ,,Datta Nimmaturi,Nutanix,Datta0,
 ,,Rachit Chauhan,Intuit,rachitchauhan43,
-Sandbox,OAuth2-Proxy,Joel Speed,Red Hat,joelspeed,https://github.com/oauth2-proxy/oauth2-proxy/blob/master/MAINTAINERS
+Sandbox,OAuth2 Proxy,Joel Speed,Red Hat,joelspeed,https://github.com/oauth2-proxy/oauth2-proxy/blob/master/MAINTAINERS
 ,,Jan Larwig,IONOS Cloud,tuunit,
 ,,JJ Łakis, ,jjlakis,


### PR DESCRIPTION
ref.: https://github.com/cncf/sandbox/issues/407
