### PR TITLE
Update project-maintainers.csv

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1474,7 +1474,7 @@ Sandbox,PipeCD,Tran Cong Khanh,CyberAgent,khanhtc1202,https://github.com/pipe-cd
 ,,Le Van Nghia,CyberAgent,nghialv,
 ,,Yoshiki Fujikane,CyberAgent,ffjlabo,
 ,,Tetsuya Kikuchi,CyberAgent,t-kikuc,
-,,Shinnosuke Sawada,CyberAgent,Warashi,
+,,Shinnosuke Sawada-Dazai,Independent,Warashi,
 Sandbox,Inspektor Gadget,Mauricio Vásquez Bernal,Microsoft,mauriciovasquezbernal,https://github.com/inspektor-gadget/inspektor-gadget/blob/main/MAINTAINERS.md
 ,,Alban Crequy,Microsoft,alban,
 ,,Francis Laniel,Microsoft,eiffel-fl,


### PR DESCRIPTION
- I'm now using "Sawada-Dazai" as GitHub Profile name, so I want to update this to keep consistency.
- I have changed jobs and the new job is not related to maintaining pipecd, so I want to update my company status to `Independent`. 

ref; https://github.com/pipe-cd/pipecd/pull/6290

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [ ] You've provided a link to documentation where the project has approved the maintainer change.
- [ ] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
