### PR TITLE
Add Rishi Anand as Kairos maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1630,6 +1630,7 @@ Sandbox,Kairos,Ettore Di Giacinto,Spectro Cloud,mudler,https://github.com/kairos
 ,,Dimitris Karakasilis,Spectro Cloud,jimmykarily,
 ,,Itxaka Serrano Garcia,Spectro Cloud,itxaka,
 ,,Mauro Morales,Spectro Cloud,mauromorales,
+,,Rishi Anand,Spectro Cloud,rishi-anand,
 Sandbox,KubeSlice,Prabhu Navali,Avesha,pnavali,https://github.com/kubeslice/kubeslice/blob/master/MAINTAINERS.md
 ,,Bharath Horatti,Avesha,bharath-avesha,
 ,,Imran Md,Avesha,narmidm,


### PR DESCRIPTION
Approval to be Kairos maintainer https://github.com/kairos-io/community/pull/16

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [x] You've provided a link to documentation where the project has approved the maintainer change.
- [x] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
