### PR TITLE
Update Dalec maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -2075,7 +2075,8 @@ Incubating,KServe,Dan Sun,Bloomberg,yuzisun,https://github.com/kserve/kserve/blo
 Sandbox,OAuth2 Proxy,Joel Speed,Red Hat,joelspeed,https://github.com/oauth2-proxy/oauth2-proxy/blob/master/MAINTAINERS
 ,,Jan Larwig,IONOS Cloud,tuunit,
 ,,JJ Łakis, ,jjlakis,
-Sandbox,Dalec,Brian Goff,Microsoft,cpuguy83,https://github.com/Azure/dalec/blob/main/MAINTAINERS.md
+Sandbox,Dalec,Brian Goff,Microsoft,cpuguy83,https://github.com/project-dalec/dalec/blob/main/MAINTAINERS.md
 ,,Jeremy Rickard,Microsoft,jrrickard,
 ,,Sertac Ozercan,Microsoft,sozercan,
-,,Adam Perlin,Microsoft,adamperlin,
+,,Peter Engelbert,Microsoft,pmengelbert,
+


### PR DESCRIPTION
Updated Dalec maintainers. Replaced Adam Perlin with Peter Engelbert. Also updated the maintainers.md link to https://github.com/project-dalec/dalec/blob/main/MAINTAINERS.md

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
