### PR TITLE
Update ahrtr's company from VMware to Broadcom

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -11,7 +11,7 @@ Graduated,Kubernetes steering,Antonio Ojea,Google,aojea,https://git.k8s.io/steer
 ,,Aravindh Puthiyaparambil,Softdrive Technologies Group Inc.,aravindhp,
 ,,Arda Guclu,Red Hat,ardaguclu,
 ,,Arnaud Meukam,Independent,ameukam,
-,,Benjamin Wang,VMware,ahrtr,
+,,Benjamin Wang,Broadcom,ahrtr,
 ,,Brady Pratt,Red Hat,jbpratt,
 ,,Bridget Kromhout,Microsoft,bridgetkromhout,
 ,,Brian McQueen,LinkedIn,xmcqueen,
@@ -376,7 +376,7 @@ Graduated,Harbor,Daniel Jiang,VMware,reasonerjt,https://github.com/goharbor/comm
 ,,Vadim Bauer,8gears,Vad1mo,
 ,Harbor: SIG Community,Orlin Vasilev,SUSE,OrlinVasilev,
 ,Harbor: SIG Docs,Abigail McCarthy,VMware,a-mccarthy,
-Graduated,etcd,Benjamin Wang,VMware,ahrtr,https://github.com/etcd-io/etcd/blob/main/OWNERS
+Graduated,etcd,Benjamin Wang,Broadcom,ahrtr,https://github.com/etcd-io/etcd/blob/main/OWNERS
 ,,Hitoshi Mitake,,mitake,
 ,,Marek Siarkowicz,Google,serathius,
 ,,Piotr Tabor,Google,ptabor,


### PR DESCRIPTION
VMware had already been acquired by Broadcom, so change the company from VMware to Broadcom

### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [ ] You've provided a link to documentation where the project has approved the maintainer changes.
- [ ] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've sent an email with the email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
