### PR TITLE
Update SPIFFE & SPIFFE Steering Committee list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -432,15 +432,15 @@ Graduated,Falco,Andrea Terzolo,Sysdig,andreagit97,https://github.com/falcosecuri
 ,,Samuel Gaist,Idiap Research Institute,sgaist,
 ,,Angelo Puglisi,Sysdig,deepskyblue86,
 ,,Gerald Combs,Wireshark Foundation,geraldcombs,
-Graduated,SPIFFE,Andres Vega,VMware,anvega,https://github.com/spiffe/spiffe/blob/main/CODEOWNERS
-,,Evan Gilman,VMware,evan2645,
-,,Andrew Jessup,HPE,ajessup,
-,,Andrew Moore,Uber,amoore877,
-,,Frederick Kautz,Doc.ai,fkautz,
-,,Dan Feldman,HPE,dfeldman,
+Graduated,SPIFFE,Arndt Schwenkschuster,Defakto,arndt-s,https://github.com/spiffe/spiffe/blob/main/CODEOWNERS
 ,,Justin Burke,Google,justinburke,
-,,Spike Curtis,Tigera,spikecurtis,
-,,Andrew Harding,VMware,azdagron,
+,,Spike Curtis,Coder,spikecurtis,
+,,Andrew Harding,Anthropic,azdagron,
+,SPIFFE Steering Committee,Arndt Schwenkschuster,Defakto,arndt-s,https://github.com/spiffe/spiffe/blob/main/ssc/README.md
+,,Noah Stride,Teleport,strideynet,
+,,Volkan Ozcelik,Broadcom,v0lkan,
+,,Mariusz Sabath,IBM Research,mrsabath,
+,,Kevin Fox,Pacific Northwest National Laboratory,kfox1111,
 Graduated,SPIRE,Sorin Dumitru,Bloomberg,sorindumitru,https://github.com/spiffe/spire/blob/main/CODEOWNERS
 ,,Evan Gilman,SPIRL,evan2645,
 ,,Marcos Yacob,HPE,MarcosDY,


### PR DESCRIPTION
It looks like we haven't updated this list in a while and that previously, the "SPIFFE" section included a mix of "maintainers of SPIFFE" and "members of the SPIFFE Steering Committee". In this PR, I've added a specific category for members of the SPIFFE Steering Committee to make this a little clearer, and I've updated the list for both categories with those members currently listed in the upstream files.

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
