### PR TITLE
Update etcd project maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -377,12 +377,12 @@ Graduated,Harbor,Daniel Jiang,VMware,reasonerjt,https://github.com/goharbor/comm
 ,Harbor: SIG Community,Orlin Vasilev,SUSE,OrlinVasilev,
 ,Harbor: SIG Docs,Abigail McCarthy,VMware,a-mccarthy,
 Graduated,etcd,Benjamin Wang,Broadcom,ahrtr,https://github.com/etcd-io/etcd/blob/main/OWNERS
-,,Hitoshi Mitake,,mitake,
 ,,Marek Siarkowicz,Google,serathius,
-,,Piotr Tabor,Google,ptabor,
 ,,Sahdev Zala,IBM,spzala,
-,,Wenjia Zhang,Google,wenjiaswe,
-,SIG etcd,James Blair,Red Hat,jmhbnz,https://github.com/kubernetes/community/tree/master/sig-etcd#leadership
+,,Wei Fu,Microsoft,fuweid,
+,SIG etcd,Ivan Valdes,Inmar Intelligence,ivanvc,https://github.com/kubernetes/community/tree/master/sig-etcd#leadership
+,,James Blair,Red Hat,jmhbnz,
+,,Siyuan Zhang,Google,siyuanfoundation,
 Graduated,Open Policy Agent,Tim Hinrichs,Apple,timothyhinrichs,https://github.com/open-policy-agent/opa/blob/master/MAINTAINERS.md
 ,,Anders Eknert,Apple,anderseknert,
 ,,Ash Narkar,Apple,ashutosh-narkar,


### PR DESCRIPTION
Remove emeritus maintainers, add Wei, and add Siyuan and Ivan to the SIG-etcd maintainers list.

This is a clean up of the etcd maintainers. The changes in the CSV follow the current state of our [OWNER](https://github.com/etcd-io/etcd/blob/main/OWNERS) and [OWNER_ALIASES](https://github.com/etcd-io/etcd/blob/main/OWNER_ALIASES) files. These files reflect the following actions:

* https://github.com/etcd-io/etcd/pull/19572
* https://github.com/etcd-io/etcd/pull/17385
* https://github.com/etcd-io/etcd/pull/17156
* Wenjia/Siyuan transition
  * https://groups.google.com/g/etcd-dev/c/1I9Q8i97Lts
  * https://github.com/kubernetes/community/issues/8478
  * https://github.com/etcd-io/etcd/pull/20203
* https://github.com/kubernetes/org/pull/5491

FYI @siyuanfoundation, @fuweid.

Thanks, @jberkus, for spotting the staleness of the etcd list.

# Checklist for maintainer updates

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
