### PR TITLE
Add William Rizzo as Kairos maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1723,6 +1723,7 @@ Sandbox,Kairos,Ettore Di Giacinto,Spectro Cloud,mudler,https://github.com/kairos
 ,,Itxaka Serrano Garcia,Spectro Cloud,itxaka,
 ,,Mauro Morales,Spectro Cloud,mauromorales,
 ,,Rishi Anand,Spectro Cloud,rishi-anand,
+,,William Rizzo,Mirantis,wrkode,
 Sandbox,KubeSlice,Prabhu Navali,Avesha,pnavali,https://github.com/kubeslice/kubeslice/blob/master/MAINTAINERS.md
 ,,Bharath Horatti,Avesha,bharath-avesha,
 ,,Imran Md,Avesha,narmidm,


### PR DESCRIPTION
Approval of @wrkode as maintainer https://github.com/kairos-io/community/pull/17


# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
