### PR TITLE
Update Kubernetes Maintainers to add seokho-son

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -80,6 +80,7 @@ Graduated,Kubernetes steering,Antonio Ojea,Google,aojea,https://git.k8s.io/steer
 ,,Rita Zhang,Microsoft,ritazh,
 ,,Saad Ali,Google,saad-ali,
 ,,Sebastian Florek,Plural,floreks,
+,,Seokho Son,Electronics and Telecommunications Research Institute,seokho-son,
 ,,Sergey Kanzhelev,Google,SergeyKanzhelev,
 ,,Shane Utt,Red Hat,shaneutt,
 ,,Shu Muto,NEC,shu-mutou,
@@ -2114,7 +2115,3 @@ Sandbox,Dalec,Brian Goff,Microsoft,cpuguy83,https://github.com/project-dalec/dal
 ,,Jeremy Rickard,Microsoft,jrrickard,
 ,,Sertac Ozercan,Microsoft,sozercan,
 ,,Peter Engelbert,Microsoft,pmengelbert,
-
-
-
-


### PR DESCRIPTION
I am adding my name (@seokho-son) to the project maintainer list in preparation for submitting a proposal to the maintainer summit.

I currently serve as a maintainer in the Kubernetes project.
- Kubernetes SIG Docs Localization Subproject Lead
  - https://github.com/kubernetes/community/tree/master/sig-docs/localization-subproject#subproject-leadership
- Maintainer of the https://github.com/kubernetes/website repository
  - sig-docs-localization-owners: https://github.com/kubernetes/website/blob/main/OWNERS_ALIASES#L33
  - sig-docs-ko-owners: https://github.com/kubernetes/website/blob/main/OWNERS_ALIASES#L151
  - website-maintainers team memeber: https://github.com/orgs/kubernetes/teams/website-maintainers/members

# Checklist for maintainer updates

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [x] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).

Let me send an email to cncf-maintainer-changes@cncf.io with the required email address after this PR is merged so the invitations to Service Desk and mailing lists can proceed.