### PR TITLE
Remove Bernd from Dapr maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1209,7 +1209,6 @@ Graduated,Dapr,Yaron Schneider,Diagrid,yaron2 ,https://github.com/dapr/community
 ,,Elena Kolevska,Diagrid,elena-kolevska,
 ,,Cassie Coyle,Diagrid,cicoyle,
 ,,Nick Greenfield,Microsoft,greenie-msft,
-,,Bernd Verst,Microsoft,berndverst,
 ,,Hal Spang,Microsoft,halspang,
 ,,Paul Yuknewicz,Microsoft,paulyuk,
 ,,Hanna Hunter,Microsoft,@hhunter-ms,
@@ -2115,6 +2114,7 @@ Sandbox,Dalec,Brian Goff,Microsoft,cpuguy83,https://github.com/project-dalec/dal
 ,,Jeremy Rickard,Microsoft,jrrickard,
 ,,Sertac Ozercan,Microsoft,sozercan,
 ,,Peter Engelbert,Microsoft,pmengelbert,
+
 
 
 


### PR DESCRIPTION
# Checklist for maintainer updates

Dapr issue: https://github.com/dapr/community/issues/684

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [X] You've provided a link to documentation where the project has approved the maintainer changes.
- [ ] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
