### PR TITLE
Revise Silver members' activity eligibility

### DIFF
--- a/policies-guidance/online-programs-guidelines.md
+++ b/policies-guidance/online-programs-guidelines.md
@@ -17,7 +17,7 @@ On-demand webinars premiere on Thursdays.
 Members 
 * Platinum members are eligible for 3 activities per quarter including live webinar, on-demand webinar, and a livestream.
 * Gold members are eligible for 3 activities per quarter including on-demand webinar or livestream (Only 1 can be livestream, you get to choose.)
-* Silver members are eligible for 2 activities per quarter including on-demand webinars and livestreams. (Only 1 can be livestream, you get to choose.)
+* Silver members are eligible for 2 on-demand webinars per year.
 * End user supporter members cannot hold a webinar.
 * CNCF Member webinars will have “member webinar” in the YouTube description.
 * All livestreams and webinars (live or on-demand) make it to a YouTube playlist on the [CNCF YouTube channel](https://www.youtube.com/@cncf).


### PR DESCRIPTION
Updated Silver members' eligibility to specify 2 on-demand webinars per year instead of activities per quarter.

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [ ] You've provided a link to documentation where the project has approved the maintainer changes.
- [ ] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
