### PR TITLE
add elohmrow to k8gb maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1008,6 +1008,7 @@ Sandbox,k8gb,Donovan Muller,Absa,donovanmuller,https://github.com/k8gb-io/k8gb/b
 ,,MichalK,Absa,kuritka,
 ,,Yury Tsarev,Upbound,ytsarev,
 ,,Andre Baptista Aguas,Open Systems,abaguas,
+,,Bradley Andersen,0ttl,elohmrow,
 Sandbox,Trickster ,James Ranson,Virga,jranson,https://github.com/trickstercache/trickster/blob/main/MAINTAINERS.md
 ,,Chris Randles,WB Discovery,crandles,
 ,,Adam Ross,Amazon,LimitlessEarth,


### PR DESCRIPTION
# Checklist for maintainer updates

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
  - https://github.com/k8gb-io/k8gb/blob/master/CODEOWNERS
  - https://github.com/k8gb-io/k8gb/pull/2170 
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
