### PR TITLE
Add new Backstage maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -891,6 +891,8 @@ Sandbox,k3s,Brad Davidson,SUSE,brandond,https://github.com/rancher/k3s/blob/mast
 Incubating,Backstage,Patrik Oldsberg,Spotify,Rugvip,https://github.com/spotify/backstage/blob/master/OWNERS.md
 ,,Fredrik Adelöw,Spotify,freben,
 ,,Ben Lambert,Spotify,benjdlambert,
+,,André Wanlin,Spotify,awanlin,
+,,Aramis Sennyey,DoorDash,aramissennyeydd,
 ,,Niklas Gustavsson,Spotify,protocol7,
 ,,Dave Zolotusky,Spotify,dzolotusky,
 ,,Pia Nilsson,Spotify,pianilsson,


### PR DESCRIPTION
# Checklist for maintainer updates

We recently added two new project maintainers for Backstage! 🎉 @aramissennyeydd and @awanlin

We updated [OWNERS.md](https://github.com/backstage/backstage/blob/master/OWNERS.md) in the following PR: https://github.com/backstage/backstage/pull/32114

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
