### PR TITLE
Update Kubescape maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1516,11 +1516,11 @@ Sandbox,HwameiStor,Liang Sun,DaoCloud,sun7927,https://github.com/hwameistor/hwam
 ,,Baofa Fan,DaoCloud,carlory,
 ,,Peng Lai,DaoCloud,peng9808,
 ,,Peter Pan,DaoCloud,panpan0000,
-Incubating,Kubescape,Bezalel Brandwine,ARMO,Bezbran,https://github.com/kubescape/kubescape/blob/master/MAINTAINERS.md#maintainers
-,,Craig Box,ARMO,craigbox,
-,,David Wertenteil,ARMO,dwertent,
-,,Rotem Refael,ARMO,rotemamsa,
+Incubating,Kubescape,Bertschy Matthias,ARMO,matthyx,https://github.com/kubescape/project-governance/blob/main/MAINTAINERS.md
 ,,Ben Hirschberg,ARMO,slashben,
+,,Rotem Refael,ARMO,rotemamsa,
+,,Amir Malka,ARMO,amirmalka,
+,,Bezalel Brandwine,Softwine,Bezbran,
 Sandbox,Carina,Zhenhua Zhang,BoCloud,ZhangZhenhua,https://github.com/carina-io/carina/blob/main/MAINTAINERS.md
 ,,Shaosong Fu,Bocloud,antmoveh,
 Sandbox,Paralus,Avinash Varma Penmetsa,Rafay,avinashpenmetsa,https://github.com/paralus/paralus/blob/main/MAINTAINERS.md
@@ -2147,5 +2147,6 @@ Sandbox,HolmesGPT,Natan Yellin,Robusta,aantn,https://github.com/HolmesGPT/holmes
 ,,Roi Glinik,Robusta,RoiGlinik,
 ,,Moshe Morad,Robusta,moshemorad,
 ,,Qingchuan Hao,Microsoft,mainred,
+
 
 


### PR DESCRIPTION
also update the link to the global list https://github.com/kubescape/project-governance/blob/main/MAINTAINERS.md

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [ ] You've provided a link to documentation where the project has approved the maintainer changes.
- [ ] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
