### PR TITLE
Add jwendell to Envoy maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -170,6 +170,7 @@ Graduated,Envoy,Matt Klein,bitdrift,mattklein123,https://github.com/envoyproxy/e
 ,,Kateryna Nezdolii,Spotify,nezdolik,
 ,,Takeshi Yoneda,Tetrate,mathetake,
 ,,Boteng Yao,Google,botengyao,
+,,Jonh Wendell,Red Hat,jwendell,
 ,Envoy: Gateway (non-voting),Xunzhuo Liu,Tencent,Xunzhuo,https://github.com/envoyproxy/gateway/blob/main/GOVERNANCE.md#steering-committee
 ,,Arko Dasgupta,OpenAI,arkodg,
 ,,Jianpeng He,Tetrate,zirain,


### PR DESCRIPTION
# Checklist for maintainer updates

https://github.com/envoyproxy/envoy/pull/41860
https://github.com/envoyproxy/envoy/blob/main/OWNERS.md#maintainers

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [x] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
