### PR TITLE
Update KEDA's link

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -600,7 +600,7 @@ Graduated,CubeFS,Haifeng Liu ,_,bladehliu,https://github.com/cubefs/cubefs/blob/
 ,,Xiaobo Yu,OPPO,cessory,
 ,,Cloudstriff,OPPO,Cloudstriff,
 ,,slasher,OPPO,sejust,
-Graduated,KEDA,Jeff Hollan,Snowflake,jeffhollan,https://github.com/kedacore/governance/blob/main/MAINTAINERS.md
+Graduated,KEDA,Jeff Hollan,Snowflake,jeffhollan,https://github.com/kedacore/governance/blob/main/MEMBERS.md
 ,,Jorge Turrado Ferrero,SCRM Lidl International Hub,jorturfer,
 ,,Zbynek Roubalik,Kedify,zroubalik,
 ,,Jan Wozniak,Kedify,wozniakjan,
@@ -2155,6 +2155,7 @@ Sandbox,HolmesGPT,Natan Yellin,Robusta,aantn,https://github.com/HolmesGPT/holmes
 ,,Roi Glinik,Robusta,RoiGlinik,
 ,,Moshe Morad,Robusta,moshemorad,
 ,,Qingchuan Hao,Microsoft,mainred,
+
 
 
 


### PR DESCRIPTION
We have renamed the page and this PR fixes the broken link

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [x] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
