### PR TITLE
fix(maintainers): Update my own information in the maintainers file

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -634,7 +634,7 @@ Graduated,Argo, Saravanan Balasubramanian,Intuit,sarabala1979,https://github.com
 ,,Isitha Subasinghe,Pipekit,isubasinghe,
 ,,Jann Fischer,Red Hat,jannfis,
 ,,Jesse Suen,Akuity,jessesuen,
-,,JM (Jason Meridth),GitHub,jmeridth,
+,,Jason Meridth,Chainguard,jmeridth,
 ,,Jonathan West,Red Hat,jgwest,
 ,,jswxstw,Independent,jswxstw,
 ,,Julie Vogelman,Intuit,juliev0,


### PR DESCRIPTION
Update my own information in the maintainers file. [Same changes in github.com/argoproj/argoproj maintainers file](https://github.com/argoproj/argoproj/pull/419)

I'm making this change so this list matches upstream Argo maintainers list and then I can request [copilot enterprise](https://contribute.cncf.io/blog/2025/12/16/github-copilot-enterprise-for-maintainers/) as a maintainer.

NOTE: Currently when I go to https://servicedesk.cncf.io/ and put in my email, I get `We couldn't submit your request. Refresh the page and try again.`. I assume that is because my email is not invited to Service Desk? Do we have a subset of people in the Argo project that have that access? I've asked in our CNCF Slack channels re: subset of maintainers.

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
  - read NOTE above whey this is currently unchecked.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
