### PR TITLE
Add OpenChoreo project's core maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -2172,7 +2172,9 @@ Sandbox,Cedar,Darin McAdams,SPIRL,D-McAdams,https://github.com/cedar-policy/.git
 ,,Patrick Jakubowski,StrongDM,patjak-dev,
 ,,Eitan Revach,Cloudinary,eitan-revach,
 ,,Tom Paulus,Cloudflare,tpaulus,
-
-
-
+Sandbox,OpenChoreo,Sameera Jayasoma,WSO2,sameerajayasoma,https://github.com/openchoreo/openchoreo
+,,Lakmal Warusawithana,WSO2,lakwarus,
+,,Binura Gunasekara,WSO2,binura-g,
+,,Tishan Dahanayaka,WSO2,tishan89,
+,,Miraj Abeysekara,WSO2,Mirage20,
 


### PR DESCRIPTION
The following document contains the list of approved core maintainers
https://github.com/openchoreo/openchoreo/blob/main/MAINTAINERS.md#core-maintainers

I also emailed the list to project-onboarding@cncf.io. 

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
