### PR TITLE
Add Rick Brouwer as a new KEDA maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -600,7 +600,7 @@ Graduated,CubeFS,Haifeng Liu ,_,bladehliu,https://github.com/cubefs/cubefs/blob/
 ,,Xiaobo Yu,OPPO,cessory,
 ,,Cloudstriff,OPPO,Cloudstriff,
 ,,slasher,OPPO,sejust,
-Graduated,KEDA (Organization),Jeff Hollan,Snowflake,jeffhollan,https://github.com/kedacore/governance/blob/main/MEMBERS.md
+Graduated,KEDA,Jeff Hollan,Snowflake,jeffhollan,https://github.com/kedacore/governance/blob/main/MEMBERS.md
 ,,Jorge Turrado Ferrero,SCRM Lidl International Hub,jorturfer,
 ,,Zbynek Roubalik,Kedify,zroubalik,
 ,,Jan Wozniak,Kedify,wozniakjan,


### PR DESCRIPTION
https://github.com/kedacore/governance/issues/135
https://github.com/kedacore/governance/blob/main/MEMBERS.md

# Checklist for maintainer updates

- [X] You've provided a link to documentation where the project has approved the maintainer changes.
- [X] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
