### PR TITLE
adds jcooklin as crossplane maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -826,6 +826,7 @@ Graduated,Crossplane,Bassam Tabbara,Upbound,bassam,https://github.com/crossplane
 ,,Mo Ying (William),IBM,morningspace,
 ,,Dario Zachow,DeutscheBahn,dariozachow,
 ,,Zong Zhe,Ant Group,zong-zhe,
+,,Joel Cooklin,Nike,jcooklin,
 Incubating,Contour,Steve Kriss,Broadcom,skriss,https://github.com/projectcontour/community/blob/master/MAINTAINERS.md
 ,,Tero Saarni,Ericsson,tsaarni,
 ,,Sunjay Bhatia,Broadcom,sunjayBhatia,


### PR DESCRIPTION
# Checklist for maintainer updates

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
  - https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md#steering-committee-1
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
