### PR TITLE
Update github handle change that was missed when affiliation changed

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1810,7 +1810,7 @@ Sandbox,Kuadrant,Jason Madigan,Red Hat,jasonmadigan,https://github.com/Kuadrant/
 ,,Didier Di Cesare,Red Hat,didierofrivia,
 ,,David Martin,Red Hat,david-martin,
 Sandbox,Score,Ben Meier,Humanitec,astromechza,https://github.com/score-spec/spec/blob/main/MAINTAINERS.md
-,,Chris Stephenson,Independent,chrishumanitec,
+,,Chris Stephenson,Independent,chris-stephenson,
 ,,Mathieu Benoit,Docker,mathieu-benoit,
 ,,Susa Tünker,Checkly,sujaya-sys,
 Sandbox,openGemini,Yu Xiang,Huawei,xiangyu5632,https://github.com/openGemini/openGemini/blob/main/MAINTAINERS.md
@@ -2209,4 +2209,5 @@ Sandbox,Cadence,Ender Demirkaya,Uber,demirkayaender,https://github.com/cadence-w
 ,,Tim Li,Uber,timl3136,
 ,,Vsevolod Kaloshin,Uber,arzonus,
 ,,Zijian Chen,Uber,Shaddoll,
+
 


### PR DESCRIPTION
I renamed my Github handle from `chrishumanitec` -> `chris-stephenson` when I left Humanitec. The underlying account is the same. This change is just to ensure consistency. There are no people being added or removed.

Original change for affiliation: 487283f5d1666b7bffc2e8eaef17a6caea114761 to project-maintainers.csv

Link to showing change of handles
https://github.com/score-spec/score-go/pull/155



> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [ x ] You've provided a link to documentation where the project has approved the maintainer changes.
- [ x ] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ x ] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people. _Change of handle only
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
