### PR TITLE
Add krinkinmu as a maintainer of Envoy and Istio projects

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -171,6 +171,7 @@ Graduated,Envoy,Matt Klein,bitdrift,mattklein123,https://github.com/envoyproxy/e
 ,,Takeshi Yoneda,Tetrate,mathetake,
 ,,Boteng Yao,Google,botengyao,
 ,,Jonh Wendell,Red Hat,jwendell,
+,,Mikhail Krinkin,Microsoft,krinkinmu,
 ,Envoy: Gateway (non-voting),Xunzhuo Liu,Tencent,Xunzhuo,https://github.com/envoyproxy/gateway/blob/main/GOVERNANCE.md#steering-committee
 ,,Arko Dasgupta,OpenAI,arkodg,
 ,,Jianpeng He,Tetrate,zirain,
@@ -1488,6 +1489,7 @@ Graduated,Istio: Steering Committee,Ameer Abbas,Google,ameer00,https://github.co
 ,,Xunzhuo Liu,Tencent,Xunzhuo,
 ,,Yangmin Zhu,Uber,yangminzhu,
 ,,Steve Zhang,Intel,zhlsunshine,
+,,Mikhail Krinkin,Microsoft,krinkinmu,
 Sandbox,Armada,Chris Martin,G-Research,d80tb7,https://github.com/G-Research/armada/blob/master/MAINTAINERS.md
 ,,Dave Gantenbein,G-Research,dave-gantenbein,
 ,,Dejan Zele Pejchev,G-Research,dejanzele,


### PR DESCRIPTION
Evidence:
- For Envoy https://github.com/envoyproxy/envoy/blob/main/OWNERS.md#maintainers
- For Istio https://github.com/istio/community/blob/master/org/teams.yaml

# Checklist for maintainer updates

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [x] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
