### PR TITLE
Remove Akri emeritus maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1171,7 +1171,7 @@ Incubating,wasmCloud,Brooks Townsend,Cosmonic,brooksmtownsend,https://github.com
 ,,Bailey Hayes,Cosmonic,ricochet,
 ,,Jordan Rash,Synadia,jordan-rash,
 ,,Colin Murphy,Adobe,cdmurph32,
-Sandbox,Akri,Gaurav Gahlot,ionos-cloud,gauravgahlot,
+Sandbox,Akri,Gaurav Gahlot,ionos-cloud,gauravgahlot,https://github.com/project-akri/akri/blob/main/CODEOWNERS
 ,,Lior Lustgarten,Microsoft,lilustga,
 ,,Marcel Bindseil,Microsoft,bindsi,
 ,,Yu Jin Kim,Microsoft,yujinkim-msft,


### PR DESCRIPTION
# Checklist for maintainer updates
Here is the current list of Akri maintainers from the Akri OWNERS file: https://github.com/project-akri/akri/blob/main/OWNERS

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [x] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm). - **Not Needed (I dont see us listed there)**
