### PR TITLE
Add lbordowitz as a maintainer for OpenTofu

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -2052,6 +2052,7 @@ Sandbox,OpenTofu,Christian Mesh,Spacelift.io,cam72cam,https://github.com/opentof
 ,,Andrei Ciobanu,Env0,yottta,
 ,,Ilia Gogotchuri,Env0,Gogotchuri,
 ,,Diógenes Fernandes,Gruntwork,diofeher,
+,,Larry Bordowitz,Harness,lbordowitz,
 Sandbox,KitOps,Gorkem Ercan,Jozu,gorkem,https://github.com/kitops-ml/kitops/blob/main/MAINTAINERS.md
 ,,Angel Misevski,Jozu,amisevsk,
 ,,Brad Micklea,Jozu,bmicklea,


### PR DESCRIPTION
This person was added as a maintainer to the OpenTofu project here: https://github.com/opentofu/opentofu/pull/3830

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
