### PR TITLE
project-maintainers.csv: cert-manager has a new maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -974,6 +974,7 @@ Graduated,cert-manager,James Munnelly,Apple,munnerz,https://github.com/cert-mana
 ,,Tim Ramlot,Venafi,inteon,
 ,,Adam Talbot,Epic Games,ThatsMrTalbot,
 ,,Erik Godding Boye,Zenior,erikgb,
+,,Hemant Joshi,Walmart,hjoshi123,
 Incubating,OpenKruise,Fei Guo,Alibaba,Fei-Guo,https://github.com/openkruise/kruise/blob/master/MAINTAINERS.md
 ,,Siyu Wang,Alibaba,FillZpp,
 ,,Zhen Zhang,Alibaba,furykerry,


### PR DESCRIPTION
The vote took place in https://github.com/cert-manager/community/pull/67.

# Checklist for maintainer updates

- [x] You've provided a link to documentation where the project has approved the maintainer changes -> https://github.com/cert-manager/community/pull/67
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
