### PR TITLE
chore: Added five people to the Dragonfly projects

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -492,6 +492,11 @@ Graduated,Dragonfly,Gaius Qi,Ant Group,gaius-qi,https://github.com/dragonflyoss/
 ,,yxxhero,Zhipu AI,yxxhero,
 ,,fcgxz2003,Dalian University of Technology,fcgxz2003,
 ,,mingcheng 吕峰军（明城）,Apache Foundation,mingcheng,
+,,Song Yan,Ant Group,imeoer,
+,,Jiang Liu,Alibaba Group,jiangliu,
+,,Kaiyong Yang,Ant Group,BraveY,
+,,PengCheng Liu,Ant Group,NehemiahMi,
+,,Baptiste Girard-Carrabin,DataDog,Fricounet,
 Sandbox,Virtual Kubelet,Ria Bhatia ,Niantic,rbitia,https://github.com/virtual-kubelet/community/blob/master/OWNERS.md
 ,,Brian Goff,Microsoft,cpuguy83,
 ,,Paulo Pires,,pires,


### PR DESCRIPTION
We intend to [migrate the subproject maintainers to the Dragonfly projects](https://github.com/dragonflyoss/community/pull/148) after [updating the community governance documents](https://github.com/dragonflyoss/community/pull/146). The project community maintainer list has been updated, so we must update the CNCF member list as well.

## Checklist for maintainer updates

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
