### PR TITLE
Add Al-Pragliola to Kubeflow maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1678,6 +1678,7 @@ Sandbox,kcp,Andy Anderson,IBM,clubanderson,https://github.com/kcp-dev/kcp/blob/m
 ,,Nelo-T. Wallus,SAP,ntnn,
 ,,Marko Mudrinic,Kubermatic,xmudrii,
 Incubating,Kubeflow,Amber Graner,Independent,akgraner,https://github.com/kubeflow/community/blob/master/MAINTAINERS.md
+,,Alessio Pragliola,Red Hat,Al-Pragliola,
 ,,Alexander Perlman,Capital One,droctothorpe,
 ,,Andrey Velichkevich,Apple,andreyvelich,
 ,,Andy Stoneberg,Red Hat,andyatmiami,


### PR DESCRIPTION
# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
  - https://github.com/kubeflow/model-registry/pull/1153
  - https://github.com/kubeflow/internal-acls/blob/master/github-orgs/kubeflow/org.yaml#L809 (https://github.com/kubeflow/internal-acls/pull/793)
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
  - https://openprofile.dev/profile/alpragliola
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
