### PR TITLE
chore: Add Hasan Awad to Shipwright

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1866,6 +1866,7 @@ Incubating,Flatcar Container Linux,Thilo Fromm,Microsoft,t-lo,https://github.com
 Sandbox,Shipwright,Enrique Encalada,IBM,qu1queee,https://github.com/shipwright-io/community/blob/main/MAINTAINERS.md
 ,,Sascha Schwarze,IBM,SaschaSchwarze0,
 ,,Adam Kaplan,Red Hat,adambkaplan,
+,,Hasan Awad,Red Hat,hasanawad94,
 Sandbox,KusionStack,Zibo He,Ant Group,adohe,https://github.com/KusionStack/community/blob/main/MAINTAINERS.md
 ,,Dayuan Li,Ant Group,SparkYuan,
 ,,Yingming Yang,Ant Group,elliotxx,


### PR DESCRIPTION
hasanawad94 was promoted to maintainer in February 2026 [1].

[1] https://github.com/shipwright-io/community/discussions/294

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [ ] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
