### PR TITLE
Update KubeFleet maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -2037,9 +2037,13 @@ Sandbox,kgateway,Art Berger,Solo.io,artberger,https://github.com/kgateway-dev/co
 ,,Will Rigby-Hall,Solo.io,williamgrh,
 ,,Yossi Mesika,Solo.io,ymesika,
 ,,Yuval Kohavi,Solo.io,yuval-k,
-Sandbox,KubeFleet,Ryan Zhang,Microsoft,ryanzhang-oss,https://github.com/Azure/fleet/blob/main/MAINTAINERS.md
+Sandbox,KubeFleet,Ryan Zhang,Microsoft,ryanzhang-oss,https://github.com/kubefleet-dev/kubefleet/blob/main/MAINTAINERS.md
 ,,Zhiying Lin,Microsoft,zhiying-lin,
 ,,Chen Yu,Microsoft,michaelawyu,
+,,Simon Waight,Microsoft,sjwaight,
+,,Yetkin Timocin,Microsoft,ytimocin,
+,,Wei Weng,Microsoft,weng271190436,
+,,Stéphane Erbrech,Microsoft,serbrech,
 Sandbox,container2wasm,Kohei Tokunaga,NTT,ktock,https://github.com/container2wasm/container2wasm/blob/main/MAINTAINERS
 Sandbox,youki,Toru Komatsu,Preferred Networks,utam0k,https://github.com/youki-dev/youki/blob/main/docs/src/community/maintainer.md
 ,,Thomas Schubart,Gitpod,Furisto,


### PR DESCRIPTION
# Checklist for maintainer updates

See updated list (approved) on main kubefleet repo: - https://github.com/kubefleet-dev/kubefleet/blob/main/MAINTAINERS.md.

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [X] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
