### PR TITLE
chore: Update Emissary-ingress maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1038,7 +1038,7 @@ Sandbox,Trickster ,James Ranson,Virga,jranson,https://github.com/trickstercache/
 Incubating,Emissary-ingress,Alice Wasko,ngrok,aliceproxy,https://github.com/emissary-ingress/emissary/blob/main/Community/MAINTAINERS.md
 ,,David Dymko,CoreWeave,ddymko,
 ,,Flynn,Buoyant,kflynn,
-,,Hamzah Qudsi,,haq204,
+,,Hamzah Qudsi,Antimetal,haq204,
 ,,Mark Schlachter,,the-wondersmith,
 ,,Phil Peble,ActiveCampaign,ppeble,
 ,,Rafael Schloming,,rhs,

--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1035,13 +1035,13 @@ Sandbox,Trickster ,James Ranson,Virga,jranson,https://github.com/trickstercache/
 ,,Chris Randles,WB Discovery,crandles,
 ,,Adam Ross,Amazon,LimitlessEarth,
 ,,Jake Nichols,Argano,jnichols-git,
-Incubating,Emissary-ingress,Aidan Hahn,,aidanhahn,https://github.com/emissary-ingress/emissary/blob/master/MAINTAINERS.md
-,,Alex Gervais,Ambassador Labs,alexgervais,
-,,Alice Wasko,Ambassador Labs,aliceproxy,
+Incubating,Emissary-ingress,Alice Wasko,ngrok,aliceproxy,https://github.com/emissary-ingress/emissary/blob/main/Community/MAINTAINERS.md
+,,David Dymko,CoreWeave,ddymko,
 ,,Flynn,Buoyant,kflynn,
-,,Lance Austin,Ambassador Labs,lanceea,
-,,Luke Shumaker,Ambassador Labs,lukeshu,
-,,Rafael Schloming,Ambassador Labs,rhs,
+,,Hamzah Qudsi,,haq204,
+,,Mark Schlachter,,the-wondersmith,
+,,Phil Peble,ActiveCampaign,ppeble,
+,,Rafael Schloming,,rhs,
 Graduated,Cilium,Aditi Ghag,Isovalent,aditighag,https://github.com/cilium/cilium/blob/master/MAINTAINERS.md
 ,,Alexandre Perrin,Isovalent,kaworu,
 ,,André Martins,Isovalent,aanm,


### PR DESCRIPTION
This is a _long_ overdue update to Emissary-ingress' maintainer list:

- [Remove Aidan Hahn](https://github.com/emissary-ingress/emissary/commit/c25961246c502e71c2dd66e7e41ecc9f384c1ad3)
- [Remove Alex Gervais](https://github.com/emissary-ingress/emissary/commit/31dd5875295ec8e313744cb5cfccc573ab677e85)
- [Add David Dymko](https://github.com/emissary-ingress/emissary/issues/4589)
- [Add Hamzah Qudsi](https://github.com/emissary-ingress/emissary/issues/4588)
- [Remove Lance Austin](https://github.com/emissary-ingress/emissary/commit/75b4a5e4454746f82d61a5fe4e068d3030bcc29c)
- [Remove Luke Shumaker](https://github.com/emissary-ingress/emissary/commit/3de3ff793e306ceeeccf82d991ac9519900172a2)
- [Add Mark Schlachter](https://github.com/emissary-ingress/emissary/pull/5766)
- [Add Phil Peble](https://github.com/emissary-ingress/emissary/pull/5727)

Additionally, we're removing Ambassador Labs from affiliations since Ambassador Labs is no more.

Signed-off-by: Flynn <emissary@flynn.kodachi.com>

# Checklist for maintainer updates

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).

Many thanks!