### PR TITLE
chore: Drop inactive Emissary maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1082,12 +1082,9 @@ Sandbox,Trickster ,James Ranson,Virga,jranson,https://github.com/trickstercache/
 ,,Adam Ross,Amazon,LimitlessEarth,
 ,,Jake Nichols,Argano,jnichols-git,
 Incubating,Emissary-ingress,Alice Wasko,ngrok,aliceproxy,https://github.com/emissary-ingress/emissary/blob/main/Community/MAINTAINERS.md
-,,David Dymko,CoreWeave,ddymko,
 ,,Flynn,Buoyant,kflynn,
-,,Hamzah Qudsi,Antimetal,haq204,
 ,,Mark Schlachter,,the-wondersmith,
 ,,Phil Peble,ActiveCampaign,ppeble,
-,,Rafael Schloming,,rhs,
 Graduated,Cilium,Aditi Ghag,Isovalent,aditighag,https://github.com/cilium/cilium/blob/master/MAINTAINERS.md
 ,,Alexandre Perrin,Isovalent,kaworu,
 ,,André Martins,Isovalent,aanm,


### PR DESCRIPTION
Drop inactive Emissary maintainers (cf https://github.com/emissary-ingress/emissary/issues/5926).

Signed-off-by: Flynn <emissary@flynn.kodachi.com>

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [x] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
