### PR TITLE
Add Alexa Griffith as KServe maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -2207,6 +2207,7 @@ Incubating,KServe,Dan Sun,Bloomberg,yuzisun,https://github.com/kserve/kserve/blo
 ,,Jooho Lee,Red Hat,Jooho,
 ,,Filippe Spolti,Red Hat,spolti,
 ,,Edgar Hernández,Red Hat,israel-hdez,
+,,Alexa Griffith,Red Hat,alexagriffith,
 ,,Jin Dong,Bloomberg,greenmoon55,
 ,,Curtis Maddalozzo,Bloomberg,cmaddalozzo,
 ,,Lize Cai,SAP,lizzzcai,


### PR DESCRIPTION
## Summary
Adding Alexa Griffith (Red Hat) as a KServe project maintainer.

## Changes
- Added entry to project-maintainers.csv under the KServe section

🤖 Generated with [Claude Code](https://claude.com/claude-code)