### PR TITLE
fix: update VS Code Kubernetes Tools maintainers list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1314,9 +1314,12 @@ Sandbox,KubeArmor,Rahul Jadhav,AccuKnox,nyrahul,https://github.com/kubearmor/Kub
 Sandbox,kube-rs,Eirik Albrigtsen,TrueLayer,clux,https://github.com/kube-rs/website/blob/main/docs/maintainers.md
 ,,Teo Klestrup Röijezon,Stackable,teozkr,
 ,,Kaz Yoshihara,Qualified,kazk,
-Sandbox,VS Code Kubernetes Tools,Ivan Towlson,Fermyon,itowlson,https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/blob/master/OWNERS.md
-,,Luca Stocchi,Red Hat,lstocchi,
-,,Bhargav Nookala,Microsoft,bnookala,
+Sandbox,VS Code Kubernetes Tools,Tatsat (Tats) Mishra,Microsoft,Tatsinnit,https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/blob/master/OWNERS.md
+,,Tejhan Diallo,Microsoft,tejhan,
+,,Suneha Bose,Microsoft,bosesuneha,
+,,David Gamero,Microsoft,davidgamero,
+,,Tom Gamble,Microsoft,gambtho,
+,,Ralph Squillace,Microsoft,squillace,
 Sandbox,Devfile,Andreas Resios,AWS,resios, https://github.com/devfile/api/blob/master/MAINTAINERS.md
 ,,Angel Misevski,Red Hat,amisevsk,
 ,,Elson Yuen,Red Hat,elsony,


### PR DESCRIPTION
### Replace former maintainers with current ownership team for the VS Code Kubernetes Tools project.

**## What this PR does**

Updates the maintainer list for the VS Code Kubernetes Tools project to reflect the current ownership team.

**## Changes**

- Removes former maintainers: 
- Adds current maintainers from Microsoft: Tatsat (Tats) Mishra, Tejhan Diallo, Suneha Bose, David Gamero, Tom Gamble, Ralph Squillace

**## Why**

The VS Code Kubernetes Tools project ownership has transitioned to a new Microsoft team. This PR updates project-maintainers.csv to accurately reflect the current maintainers as listed in the [OWNERS.md](https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/blob/master/OWNERS.md).


# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [ ] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
