### PR TITLE
Add new maintainer for Keycloak, and update affiliation for existing …

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1630,12 +1630,13 @@ Sandbox,Clusternet,Di Xu,Tencent,dixudx,https://github.com/clusternet/clusternet
 ,,Yiwei Chen,Independent,yiwei-C,
 Incubating,Keycloak,Stian Thorgersen,IBM,stianst,https://github.com/keycloak/keycloak/blob/main/MAINTAINERS.md
 ,,Alexander Schwartz,IBM,ahus1,
-,,Marek Posolda,Red Hat,mposolda,
-,,Pedro Igor,Red Hat,pedroigor,
+,,Marek Posolda,IBM,mposolda,
+,,Pedro Igor,IBM,pedroigor,
+,,Ricardo Martin,IBM,rmartinc,
 ,,Sebastian Schuster,Bosch,sschu,
-,,Stan Silvert,Red Hat,ssilvert,
+,,Stan Silvert,IBM,ssilvert,
 ,,Takashi Norimatsu,Hitachi,tnorimat,
-,keycloak,Thomas Darimont,Identity Tailor GmbH,thomasdarimont,https://github.com/keycloak/keycloak/blob/main/MAINTAINERS.md
+,,Thomas Darimont,Identity Tailor GmbH,thomasdarimont,https://github.com/keycloak/keycloak/blob/main/MAINTAINERS.md
 ,,Václav Muzikář,IBM,vmuzikar,
 ,,Steven Hawkins,IBM,shawkins,
 Sandbox,Kepler,Vimal Kumar,Red Hat,vimalk78,https://github.com/sustainable-computing-io/kepler/blob/main/MAINTAINERS.md


### PR DESCRIPTION
Adding new maintainer for the Keycloak project, see https://github.com/keycloak/keycloak/pull/48672 / https://github.com/keycloak/keycloak/blob/main/MAINTAINERS.md

Updated company name for existing maintainers that moved to IBM.


# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
