### PR TITLE
ci: pin contents: read on the 3 remaining PR checks

### DIFF
--- a/.github/workflows/e2e-license-site.yml
+++ b/.github/workflows/e2e-license-site.yml
@@ -9,6 +9,9 @@ on:
       - 'license-exceptions/playwright.config.js'
       - 'license-exceptions/package.json'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     name: Run E2E Tests

--- a/.github/workflows/validate-csv.yml
+++ b/.github/workflows/validate-csv.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "project-maintainers.csv"
 
+permissions:
+  contents: read
+
 jobs:
   validate-csv:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-exceptions.yml
+++ b/.github/workflows/validate-exceptions.yml
@@ -6,6 +6,9 @@ on:
       - 'license-exceptions/exceptions.json'
       - 'license-exceptions/schema/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds an explicit `permissions: contents: read` block to the three PR-time validation workflows still inheriting org defaults:

- `e2e-license-site.yml` — Playwright e2e for the License Exceptions site.
- `validate-csv.yml` — `krook/csv-lint` against `project-maintainers.csv`.
- `validate-exceptions.yml` — `ajv` JSON Schema validation against `exceptions.json`.

YAML validated locally.