### PR TITLE
KubeVirt: Add maintainer Itamar Holder

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -589,6 +589,7 @@ Incubating,KubeVirt,Vladik Romanovsky,Red Hat,vladikr,https://github.com/kubevir
 ,,Ryan Hallisey,Nvidia,rthallisey,
 ,,Andrew Burden,Red Hat,aburdenthehand,
 ,,Ľuboslav Pivarč,Red Hat,xpivarc,
+,,Itamar Holder,Red Hat,iholder101,
 Incubating,Longhorn,Sheng Yang,SUSE,yasker,https://github.com/longhorn/longhorn/blob/master/MAINTAINERS
 ,,Shuo Wu,SUSE,shuo-wu,
 ,,David Ko,SUSE,innobead,


### PR DESCRIPTION
# Checklist for maintainer updates

Itamar was voted in as a project maintainer for KubeVirt last month:
Our maintainer list: https://github.com/kubevirt/community/blob/main/MAINTAINERS.md

(Apologies for the delay)


> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
