### PR TITLE
Add Alessandro Cannarella as maintainer of Falco

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -447,6 +447,7 @@ Graduated,Falco,Andrea Terzolo,Sysdig,andreagit97,https://github.com/falcosecuri
 ,,Gerald Combs,Wireshark Foundation,geraldcombs,
 ,,Iacopo Rozzo,Sysdig,irozzo-1A,
 ,,Roberto Scolaro,Sysdig,therealbobo,
+,,Alessandro Cannarella,Sysdig,c2ndev,
 Graduated,SPIFFE,Arndt Schwenkschuster,Defakto,arndt-s,https://github.com/spiffe/spiffe/blob/main/CODEOWNERS
 ,,Justin Burke,Google,justinburke,
 ,,Spike Curtis,Coder,spikecurtis,


### PR DESCRIPTION
Find https://github.com/falcosecurity/test-infra/pull/2019 the PR approving my promotion to core maintainer of the Falco project.

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
