### PR TITLE
ci: declare workflow-level `contents: read` on validate-csv and validate-exceptions

### DIFF
--- a/.github/workflows/validate-csv.yml
+++ b/.github/workflows/validate-csv.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "project-maintainers.csv"
 
+permissions:
+  contents: read
+
 jobs:
   validate-csv:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-exceptions.yml
+++ b/.github/workflows/validate-exceptions.yml
@@ -6,6 +6,9 @@ on:
       - 'license-exceptions/exceptions.json'
       - 'license-exceptions/schema/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Both workflows just validate CSV / exceptions files. No GitHub API writes, so workflow-level `contents: read` is the right cap.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.