### PR TITLE
Remove duplicate kagent listings from project maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -2168,13 +2168,6 @@ Sandbox,Hyperlight,Dan Chiarlone,Microsoft,danbugs,https://github.com/hyperlight
 Sandbox,urunc,Charalampos Mainas,Nubificus,cmainas,https://urunc.io/developer-guide/maintainers/
 ,,Georgios Ntoutsos,Nubificus,gntouts,
 ,,Anastassios Nanos,Nubificus,ananos,
-Sandbox,kagent,Art Berger,Solo.io,artberger,https://github.com/kagent-dev/community/blob/main/MAINTAINERS.md
-,,Eitan Yarmush,Solo.io,EItanya,
-,,Lin Sun,Solo.io,linsun,
-,,Nadine Spies,Solo.io,Nadine2016,
-,,Peter Jausovec,Solo.io,peterj,
-,,Scott Weiss,Solo.io,ilackarms,
-,,Yuval Kohavi,Solo.io,yuval-k,
 Sandbox,xregistry,Doug Davis,,duglin,https://github.com/xregistry/spec/blob/main/OWNERS
 ,,Klaus Deissner,SAP,deissnerk,
 Sandbox,composefs,Alexander Larsson,Red Hat,alexl,https://github.com/composefs/composefs/blob/main/MAINTAINERS.md


### PR DESCRIPTION
This PR removes a duplicate, incomplete Kagent block from project-maintainers.csv and keeps a single canonical Kagent entry with the full maintainer set.

What changed:

Removed the earlier duplicate Kagent entry that was missing dimetron.
Kept the complete Kagent entry that includes:
artberger
dimetron
EItanya
ilackarms
linsun
Nadine2016
peterj
yuval-k
https://github.com/kagent-dev/.project/blob/main/maintainers.yaml

Why:
Prevents conflicting/duplicate maintainer data for Kagent.
Ensures only one authoritative Kagent maintainer list exists in the CSV.
Validation:

Confirmed only one Kagent block remains in project-maintainers.csv.
Confirmed the remaining block matches the requested maintainer list exactly.