### PR TITLE
Update etcd leadership to reflect current project status

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -43,7 +43,6 @@ Graduated,Kubernetes steering,Antonio Ojea,Google,aojea,https://git.k8s.io/steer
 ,,Ian Coldwater,Independent,IanColdwater,
 ,,Ivan Valdes,Inmar Intelligence,ivanvc,
 ,,Jack Francis,Microsoft,jackfrancis,
-,,James Blair,Red Hat,jmhbnz,
 ,,Jan Šafránek,Red Hat,jsafrane,
 ,,Janet Kuo,Google,janetkuo,
 ,,Jeremy Olmsted-Thompson,Google,jeremyot,
@@ -53,6 +52,7 @@ Graduated,Kubernetes steering,Antonio Ojea,Google,aojea,https://git.k8s.io/steer
 ,,Joel Speed,Red Hat,joelspeed,
 ,,John Belamaric,Google,johnbelamaric,
 ,,Jordan Liggitt,Google,liggitt,
+,,Josh Berkus,Red Hat,jberkus,
 ,,Justin Santa Barbara,Google,justinsb,
 ,,Kaslin Fields,Google,kaslin,
 ,,Kensei Nakada,Independent,sanposhiho,
@@ -389,13 +389,6 @@ Graduated,Harbor,Daniel Jiang,VMware,reasonerjt,https://github.com/goharbor/comm
 ,,Vadim Bauer,8gears,Vad1mo,
 ,Harbor: SIG Community,Orlin Vasilev,SAP,OrlinVasilev,
 ,,Henry Zhang,GRG Banking,hainingzhang,
-Graduated,etcd,Benjamin Wang,Broadcom,ahrtr,https://github.com/etcd-io/etcd/blob/main/OWNERS
-,,Marek Siarkowicz,Google,serathius,
-,,Sahdev Zala,IBM,spzala,
-,,Wei Fu,Microsoft,fuweid,
-,SIG etcd,Ivan Valdes,Inmar Intelligence,ivanvc,https://github.com/kubernetes/community/tree/master/sig-etcd#leadership
-,,James Blair,Red Hat,jmhbnz,
-,,Siyuan Zhang,Google,siyuanfoundation,
 Graduated,Open Policy Agent,Tim Hinrichs,Apple,timothyhinrichs,https://github.com/open-policy-agent/opa/blob/master/MAINTAINERS.md
 ,,Anders Eknert,Apple,anderseknert,
 ,,Ash Narkar,Apple,ashutosh-narkar,


### PR DESCRIPTION
# Checklist for maintainer updates

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).

Changes to reflect current etcd status and membership:

1. etcd is part of Kubernetes now, and is SIG-etcd.  As such, the separate Etcd project listing (which is mostly the same people) is being deleted.  As such, all SIG-etcd leaders are being added under Kubernetes Maintainers.
2. Current SIG-etcd leadership can be [found in SIGS file](https://github.com/kubernetes/community/tree/main/sig-etcd).



