### PR TITLE
improves accuracy of message reporting steps on slack-guidelines.md 

### DIFF
--- a/policies-guidance/slack-guidelines.md
+++ b/policies-guidance/slack-guidelines.md
@@ -16,7 +16,7 @@ Abuse of the voice/video calling features to call users without their permission
 
 ## Reporting a Problem
 
-The CNCF Slack has an integrated tool for reporting issues. It may be accessed by clicking on "More actions", the "..." to the right of a message, and selecting Report message.
+The CNCF Slack has an integrated tool for reporting issues with messages. It may be accessed on the <kbd>More actions</kbd> menu, by clicking on the <kbd>⋮</kbd> icon to the right of a message, and selecting <kbd>Report to Slack</kbd>.
 
 Slack guidelines patterned after the [HubSpot Developer Slack Code of Conduct](https://designers.hubspot.com/slack/code-of-conduct) and the [Kubernetes Slack Guidelines](https://github.com/kubernetes/community/blob/master/communication/slack-guidelines.md).
 


### PR DESCRIPTION
Adds kbd formatting for Slack UI components, replaces ... with⋮

Arose out of reviewing our moderation policies on cloud-native Slack for a Service Desk request logged by @trask

I 'rotated' the ... to <kbd>⋮</kbd> for the <kbd>More Actions</kbd> menu option and added `<kbd> </kbd>` formatting to pop the UI Slack components; 

We need to better publicize this workflow within cloud-native slack, this doc is picked up by ask.cncf.io so this is a small step in that direction