### PR TITLE
Update Cedar Policy maintainer list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -2255,10 +2255,11 @@ Sandbox,Cedar,Darin McAdams,SPIRL,D-McAdams,https://github.com/cedar-policy/.git
 ,,Ali Dowair,Delinea,adowair,
 ,,Patrick Jakubowski,Delinea,patjakdev,
 ,,Yanran Zeng,Delinea,YanranZeng1,
-,,Eitan Revach,Cloudinary,eitan-revach,
+,,Eitan Revach,,eitanre2,
 ,,Tom Paulus,Cloudflare,tpaulus,
 ,,Victor Nicolet,Amazon,victornicolet,
 ,,Julian Lovelock,Amazon,iamatjlovelock,
+,,Lucas Käldström,Upbound,luxas,
 Sandbox,OpenChoreo,Sameera Jayasoma,WSO2,sameerajayasoma,https://github.com/openchoreo/openchoreo/blob/main/MAINTAINERS.md
 ,,Lakmal Warusawithana,WSO2,lakwarus,
 ,,Binura Gunasekara,WSO2,binura-g,


### PR DESCRIPTION
Synced with https://github.com/cedar-policy/.github/blob/main/MAINTAINERS.md

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
  - https://github.com/cedar-policy/.github/pull/31
  - https://github.com/cedar-policy/.github/pull/26 
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [x] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
  - https://github.com/cncf/gitdm/pull/1164 I joined Upbound more than two years ago, but seems I forgot to update it in gitdm before now.
