### PR TITLE
Remove xsahxl from Serverless Devs maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1211,7 +1211,6 @@ Sandbox,Serverless Devs,Anycodes,National University of Defense Technology,anyco
 ,,Kun Yuan,Alibaba Cloud,heimanba,
 ,,Shoushuai Wang,Boyan,wss-git,
 ,,Renda Wang,Alibaba Cloud,lowkeyrd ,
-,,Huali Shi,Boyan,xsahxl,
 ,,Qing Wang,Alibaba Cloud,hanxie-crypto,
 ,,Song Luo,Alibaba Cloud,rsonghuster,
 ,,Chao Deng,,DevDengChao,


### PR DESCRIPTION
Removing myself as a maintainer of Serverless Devs per CNCF sandbox request (cncf/sandbox#169).