### PR TITLE
Add bitoku to CRI-O maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -410,6 +410,7 @@ Graduated,CRI-O,Mrunal Patel,Red Hat,mrunalp,https://github.com/cri-o/cri-o/blob
 ,,Fabiano Fidêncio,Intel,fidencio,
 ,,Kir Kolyshkin,Red Hat,kolyshkin,
 ,,Sohan Kunkerkar,Red Hat,sohankunkerkar,
+,,Ayato Tokubi,Red Hat,bitoku,
 Graduated,TiKV,Siddon Tang,PingCAP,siddontang,https://github.com/tikv/tikv/blob/master/MAINTAINERS.md
 ,,Jay Li,PingCAP,busyjay,
 ,,Jinpeng Zhang,PingCAP,zhangjinpeng1987,


### PR DESCRIPTION
# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
https://github.com/cri-o/cri-o/blob/main/OWNERS_ALIASES
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
