### PR TITLE
Update a Metal3 maintainer's name following last name change

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -973,7 +973,7 @@ Incubating,metal3-io,Muhammad Adil Ghaffar,Ericsson Software Technology,adilGhaf
 ,,Iury Gregory Melo Ferreira,Red Hat,iurygregory,
 ,,Kashif Khan,Ericsson Software Technology,kashifest,
 ,,Lennart Jern,Ericsson Software Technology,lentzi90,
-,,Peppi-Lotta Saari,Ericsson Software Technology,peppi-lotta,
+,,Peppi-Lotta Kurjenhovi,Ericsson Software Technology,peppi-lotta,
 ,,Adam Rozman,Ericsson Software Technology,Rozzii,
 ,,Sunnat Samadov,Ericsson Software Technology,Sunnatillo,
 ,,Moshiur Rahman,Ericsson Software Technology,smoshiur1237,


### PR DESCRIPTION
I'm updating my name because my last name has changed. This is the name I'm now using everywhere and it matches my LFX Individual Dashboard profile
