### PR TITLE
synchronize in-toto maintainers from recent election

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -563,7 +563,8 @@ Graduated,Flux,Stefan Prodan,ControlPlane,stefanprodan,https://github.com/fluxcd
 Graduated,In-Toto,Santiago Torres-Arias,Purdue University,SantiagoTorres,https://github.com/in-toto/community/blob/main/STEERING-COMMITTEE.md
 ,,Justin Cappos,New York University,JustinCappos,
 ,,Jack Kelly,ControlPlane,06kellyjac,
-,,Trishank Karthik Kuppusamy,Apple,trishankatdatadog,
+,,John Kjell,ControlPlane,jkjell,
+,,Aditya Sirish A Yelgundhalli,Bloomberg,adityasaky,
 Incubating,Strimzi,Jakub Scholz,Cloudera,scholzj,https://github.com/strimzi/strimzi-kafka-operator/blob/master/MAINTAINERS
 ,,Paolo Patierno,IBM,ppatierno,
 ,,Tom Bentley,IBM,tombentley,


### PR DESCRIPTION
https://github.com/in-toto/community/blob/main/STEERING-COMMITTEE.md

# Checklist for maintainer updates

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
