### PR TITLE
Add Apicurio project maintainers to the maintainers list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -2369,3 +2369,6 @@ Sandbox,llm-d,Abdullah Gharaibeh,Google,ahg-g,https://github.com/llm-d/llm-d/blo
 ,,Carlos Costa,IBM,chcost,
 ,,Clayton Coleman (inactive while on leave),Google,smarterclayton,
 ,,Robert Shaw,Red Hat,robertgshaw2-redhat,
+Sandbox,Apicurio,Eric Wittmann,Red Hat,ericwittmann,
+,,Jakub Senko,Individual - No Account,jsenko,
+,,Carles Arnal,Individual - No Account,carlesarnal,


### PR DESCRIPTION
Create to match https://github.com/Apicurio/.project/blob/main/maintainers.yaml and PCC records