### PR TITLE
Add laurall974 to Kepler maintainer list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1662,6 +1662,7 @@ Sandbox,Kepler,Vimal Kumar,Red Hat,vimalk78,https://github.com/sustainable-compu
 ,,Sunyanan Choochotkaew,IBM,sunya-ch,
 ,,Niki Manoledaki,Grafana Labs,nikimanoledaki,
 ,,Vasco Gervasi,,yellowhat,
+,,Laura Llinares,CERN,laurall974,
 Sandbox,SlimToolkit,Kyle Quest,,kcq,https://github.com/slimtoolkit/slim/blob/master/MAINTAINERS.md
 ,,Ivan Velichko,,iximiuz,
 Sandbox,SlimFaas,Guillaume Chervet,AXA France,guillaume-chervet,https://github.com/SlimPlanet/SlimFaas/blob/main/MAINTAINERS.md


### PR DESCRIPTION
We would like to add Laura (@laurall974) as a new maintainer of Kepler project supported by her continuous and significant contributions to the project.

Nomination issue: 
- https://github.com/sustainable-computing-io/kepler/issues/2485

Maintainer update PR approved and merged:
- https://github.com/sustainable-computing-io/kepler/pull/2486

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
