### PR TITLE
Updated OpenFGA maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1443,7 +1443,7 @@ Incubating, OpenFGA, Adrian Tam, Okta, adriantam, https://github.com/openfga/com
 ,,Andres Aguiar, Okta, aaguiarz,
 ,,Anurag Bandyopadhyay, Okta, SoulPancake,
 ,,Dan Cech, Grafana Labs, DanCech,
-,,Daniel Yeam, Okta, dyeam0,
+,,Alberto Perdomo, Okta, albertoperdomo,
 ,,Ewan Harris, Okta, ewanharris,
 ,,Jakub Hertyk, Okta, curfew-marathon,
 ,,Jim Anderson, Okta, jimmyjames,


### PR DESCRIPTION
Replaced dyeam0 with albertoperdomo

# Checklist for maintainer updates

https://github.com/openfga/community/blob/main/MAINTAINERS.md.

- [X] You've provided a link to documentation where the project has approved the maintainer changes.
- [X] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [X] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
