### PR TITLE
chore: Drop Adam Kaplan as Shipwright Maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1939,7 +1939,6 @@ Incubating,Flatcar Container Linux,Thilo Fromm,Microsoft,t-lo,https://github.com
 ,,Lexi Nadolski,Microsoft,lexinadolski,
 Sandbox,Shipwright,Enrique Encalada,IBM,qu1queee,https://github.com/shipwright-io/community/blob/main/MAINTAINERS.md
 ,,Sascha Schwarze,IBM,SaschaSchwarze0,
-,,Adam Kaplan,Red Hat,adambkaplan,
 ,,Hasan Awad,Red Hat,hasanawad94,
 Sandbox,KusionStack,Zibo He,Ant Group,adohe,https://github.com/KusionStack/community/blob/main/MAINTAINERS.md
 ,,Dayuan Li,Ant Group,SparkYuan,


### PR DESCRIPTION
I am taking on a new role at a different company, and as a result I will not have the capacity to serve as a maintainer for Shipwright. I am therefore stepping down in the best interests of the project.

PR removing me as maintainer: https://github.com/shipwright-io/community/pull/310

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
