### PR TITLE
Update SPIFFE/SPIRE Maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -445,14 +445,14 @@ Graduated,Falco,Andrea Terzolo,Sysdig,andreagit97,https://github.com/falcosecuri
 ,,Roberto Scolaro,Sysdig,therealbobo,
 ,,Alessandro Cannarella,Sysdig,c2ndev,
 Graduated,SPIFFE,Arndt Schwenkschuster,Defakto,arndt-s,https://github.com/spiffe/spiffe/blob/main/CODEOWNERS
-,,Justin Burke,Google,justinburke,
-,,Spike Curtis,Coder,spikecurtis,
+,,Sorin Dumitru,Bloomberg,sorindumitru,
+,,Noah Stride,Teleport,strideynet,
 ,,Andrew Harding,Anthropic,azdagron,
 ,SPIFFE Steering Committee,Arndt Schwenkschuster,Defakto,arndt-s,https://github.com/spiffe/spiffe/blob/main/ssc/README.md
 ,,Noah Stride,Teleport,strideynet,
 ,,Volkan Ozcelik,Broadcom,v0lkan,
 ,,Mariusz Sabath,IBM Research,mrsabath,
-,,Kevin Fox,Pacific Northwest National Laboratory,kfox1111,
+,,Sorin Dumitru,Bloomberg,sorindumitru,
 Graduated,SPIRE,Sorin Dumitru,Bloomberg,sorindumitru,https://github.com/spiffe/spire/blob/main/CODEOWNERS
 ,,Evan Gilman,SPIRL,evan2645,
 ,,Marcos Yacob,HPE,MarcosDY,


### PR DESCRIPTION
Apologies, looks like we've been remiss in updating the central maintainers CSV. This PR brings the maintainers list in line with our authoritative lists.

Documentation:
- https://github.com/spiffe/spiffe/blob/main/CODEOWNERS
- https://github.com/spiffe/spiffe/blob/main/ssc/README.md
- https://github.com/spiffe/spire/blob/main/CODEOWNERS

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
