### PR TITLE
project-maintainers: update containerd maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -206,15 +206,13 @@ Graduated,CoreDNS,Chris O'Haver,Infoblox,chrisohaver,https://github.com/coredns/
 ,,Sandeep Rajan,Infoblox,rajansandeep,
 ,,Michael Grosser,,stp-ip,
 ,,Ben Kochie,GitLab,superq,
-Graduated,containerd,Michael Crosby,Apple,crosbymichael,https://github.com/containerd/project/blob/master/MAINTAINERS
-,,Derek McGowan,Docker,dmcgowan,
+Graduated,containerd,Derek McGowan,Docker,dmcgowan,https://github.com/containerd/.project/blob/master/MAINTAINERS
 ,,Phil Estes,Amazon,estesp,
 ,,Akihiro Suda,NTT,AkihiroSuda,
 ,,Mike Brown,IBM,mikebrow,
 ,,Maksym Pavlenko,NVIDIA,mxpv,
 ,,Wei Fu,Microsoft,fuweid,
 ,,Davanum Srinivas,Nvidia,dims,
-,,Kevin Parsons,Microsoft,kevpar,
 ,,Kazuyoshi Kato,Fly.io,kzys,
 ,,Samuel Karp,Google,samuelkarp,
 ,,Kirtana Ashok,Microsoft,kiashok,


### PR DESCRIPTION
Synchronize containerd maintainers with maintainers.yaml in containerd/.project.

- kevpar removed in https://github.com/containerd/.project/pull/135
- crosbymichael removed in https://github.com/containerd/.project/pull/144

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [ ] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).

I have no way of knowing the status of LFX Individual Dashboard profiles.

cc @ahmadqasembader