### PR TITLE
Add Zhenyu Chen as CoreDNS maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -206,6 +206,7 @@ Graduated,CoreDNS,Chris O'Haver,Infoblox,chrisohaver,https://github.com/coredns/
 ,,Sandeep Rajan,Infoblox,rajansandeep,
 ,,Michael Grosser,,stp-ip,
 ,,Ben Kochie,GitLab,superq,
+,,Zhenyu Chen,,houyuwushang,
 Graduated,containerd,Derek McGowan,Docker,dmcgowan,https://github.com/containerd/.project/blob/master/MAINTAINERS
 ,,Phil Estes,Amazon,estesp,
 ,,Akihiro Suda,NTT,AkihiroSuda,


### PR DESCRIPTION
## Summary

Add Zhenyu Chen (`@houyuwushang`) to the CoreDNS maintainer records following the maintainer invitation and merged global CODEOWNERS update in CoreDNS PR #8310.

Approval and current maintainer list:

- https://github.com/coredns/coredns/pull/8310#issuecomment-5125218737
- https://github.com/coredns/coredns/blob/master/CODEOWNERS

LFX OpenProfile:

- https://openprofile.dev/profile/houyuwushang

# Checklist for maintainer updates

> [!NOTE]
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).