### PR TITLE
Update Telepresence maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -457,10 +457,9 @@ Graduated,SPIRE,Sorin Dumitru,Bloomberg,sorindumitru,https://github.com/spiffe/s
 ,,Agustin Martinez Fayo,HPE,amartinezfayo,
 ,,Ryan Turner,Cielara AI,rturner3,
 ,,Kevin Fox,PNNL,kfox1111,
-Sandbox,Telepresence,Jose Cortes,Datawire,josecv,https://github.com/telepresenceio/telepresence/blob/release/v2/MAINTAINERS.md
-,,Kévin Lambert,Datawire,knlambert,
-,,Nick Powell,Datawire,njayp,
-,,Thomas Hallgren,Datawire,thallgren,
+Sandbox,Telepresence,Thomas Hallgren,Polar Sky,thallgren,https://github.com/telepresenceio/telepresence/blob/release/v2/MAINTAINERS.md
+,,Blazej Gruszka,Displate,bgruszka,
+,,Nick Powell,,njayp,
 Incubating,Cortex,Alan Protasio,Amazon Web Services,alanprot,https://github.com/cortexproject/cortex/blob/master/MAINTAINERS.md
 ,,Ben Ye,Amazon Web Services,yeya24,
 ,,Charlie Le,Apple,CharlieTLe,


### PR DESCRIPTION
Syncs the Telepresence rows in `project-maintainers.csv` with the project's [MAINTAINERS.md](https://github.com/telepresenceio/telepresence/blob/release/v2/MAINTAINERS.md): Jose Cortes and Kévin Lambert have moved to maintainers emeriti, Blazej Gruszka has joined, and the Datawire affiliations are updated (the company no longer exists).

Part of the project's dot-project onboarding (telepresenceio/.project#1).