### PR TITLE
project-maintainers: add Jeff Spahr for Kubeflow

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1760,6 +1760,7 @@ Graduated,Kubeflow,Amber Graner,Independent,akgraner,https://github.com/kubeflow
 ,,Ilias Katsakioris,HPE,elikatsis,
 ,,James Liu,Google,zijianjoy,
 ,,James Wu,Google,james-jwu,
+,,Jeff Spahr,,jeffspahr,
 ,,Jiaxin Shan,Bytedance,Jeffwan,
 ,,Johnu George,Nutanix,johnugeorge,
 ,,Jon Burdo,Red Hat,jonburdo,


### PR DESCRIPTION
# Checklist for maintainer updates

- [x] The project approved the maintainer change in https://github.com/kubeflow/pipelines/pull/13908.
- [x] The maintainer also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] The maintainer sent their email address to <cncf-maintainer-changes@cncf.io> for Service Desk and mailing-list invitations.
- [ ] Optional: The maintainer also sent an affiliation update to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).

## Summary

Add Jeff Spahr (`jeffspahr`) to the Kubeflow maintainer list following promotion to a root Kubeflow Pipelines approver/maintainer.

## Validation

- Parsed `project-maintainers.csv` with Python's standard-library CSV parser.
- Confirmed every nonblank row has six columns.
- Confirmed the diff contains exactly one added maintainer row.
