### PR TITLE
Add Chuanhao Jin as a KubeEdge maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -497,6 +497,7 @@ Sandbox,Virtual Kubelet,Ria Bhatia ,Niantic,rbitia,https://github.com/virtual-ku
 ,,Ben Corrie,VMware,corrieb,
 ,,Sargun Dhillon ,Netflix,sargun,
 Graduated,KubeEdge,Ce Zheng,DaoCloud,zc2638,https://github.com/kubeedge/kubeedge/blob/master/MAINTAINERS.md
+,,Chuanhao Jin,Bluedot,DoisLONG,
 ,,Dave Chen,ARM,chendave,
 ,,Fei Xu,Huawei,fisherxu,
 ,,Jiawei Liu,DaoCloud,JiaweiGithub,


### PR DESCRIPTION
## Summary

Add Chuanhao Jin (`@DoisLONG`) to the CNCF KubeEdge maintainer records following the approved and merged KubeEdge maintainer nomination.

Approval and current maintainer list:

- https://github.com/kubeedge/kubeedge/pull/7036
- https://github.com/kubeedge/kubeedge/blob/master/MAINTAINERS.md

LFX OpenProfile:

- https://openprofile.dev/profile/chuanhao

# Checklist for maintainer updates

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).