### PR TITLE
Revert "update project-maintainers.csv"

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -9,7 +9,6 @@ Graduated,Kubernetes steering,Antonio Ojea,Google,aojea,https://git.k8s.io/steer
 ,,Sascha Grunert,Red Hat,saschagrunert,
 ,Kubernetes maintainers,Adolfo García Veytia,"Carabiner Systems, Inc",puerco,
 ,,Adrian Moisey,SalesLoft,adrianmoisey,
-,,Ajay Sundar Karuppasamy, Google, ajaysundark,
 ,,Anish Ramasekar,Microsoft,aramase,
 ,,Aravindh Puthiyaparambil,Softdrive Technologies Group Inc.,aravindhp,
 ,,Arda Guclu,Red Hat,ardaguclu,


### PR DESCRIPTION
Reverts cncf/foundation#1483

Not a maintainer, they are a subproject owner. K8s has their own policy for who is a defined maintainer.