### PR TITLE
Update Cozystack maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -2034,8 +2034,13 @@ Sandbox,Ratify,Akash Singhal,Microsoft,akashsinghal,https://github.com/ratify-pr
 Sandbox,Tokenetes,Atul Tulshibagwale,SGNL,tulshi,https://github.com/tokenetes/.github/blob/main/MAINTAINERS.md
 ,,Chiranjeewee Koirala,SGNL,kchiranjewee63,
 Sandbox,Cozystack,Andrei Kvapil,AENIX,kvaps,https://github.com/cozystack/cozystack/blob/main/MAINTAINERS.md
-,,George Gaal,AENIX,gecube,
-,,Kingdon Barrett,Navteca,kingdonb,
+,,Aleksei Sviridkin,AENIX,lexfrei,
+,,Daniil Miasnikov,AENIX,myasnikovdaniil,
+,,Ivan Okhotnikov,AENIX,IvanHunters,
+,,Kingdon Barrett,Urmanac,kingdonb,
+,,Mattia Eleuteri,Hidora,mattia-eleuteri,
+,,Matthieu Robin,Hidora,matthieu-robin,
+,,Timofei Larkin,AENIX,lllamnyp,
 ,,Timur Tukaev,AENIX,tym83,
 Sandbox,Spin,Brian Hardock,Fermyon,fibonacci1729,https://github.com/spinframework/spin/blob/main/MAINTAINERS.md
 ,,Ivan Towlson,Fermyon,itowlson,


### PR DESCRIPTION
Sync the CNCF roster with Cozystack's [`MAINTAINERS.md`](https://github.com/cozystack/cozystack/blob/main/MAINTAINERS.md), which this CSV has drifted from.

**Added**

| Maintainer | GitHub | Company | Approved in |
| --- | --- | --- | --- |
| Aleksei Sviridkin | `lexfrei` | AENIX | cozystack/cozystack#3462 |
| Daniil Miasnikov | `myasnikovdaniil` | AENIX | cozystack/cozystack#3462 |
| Ivan Okhotnikov | `IvanHunters` | AENIX | cozystack/cozystack#3462 |
| Timofei Larkin | `lllamnyp` | AENIX | cozystack/cozystack#2719 |
| Mattia Eleuteri | `mattia-eleuteri` | Hidora | cozystack/cozystack#2345 |
| Matthieu Robin | `matthieu-robin` | Hidora | cozystack/cozystack#2346 |

**Removed** — George Gaál (`gecube`), moved to emeritus in cozystack/cozystack#3462.

**Corrected** — Kingdon Barrett's affiliation, Navteca → Urmanac, per the current `MAINTAINERS.md`.

Andrei Kvapil stays as the block's first row so the tier and the governance link keep their place; the remaining entries are alphabetical.

The project also documents a Reviewer role in [`CONTRIBUTOR_LADDER.md`](https://github.com/cozystack/cozystack/blob/main/CONTRIBUTOR_LADDER.md). Reviewers own an area rather than the project and are deliberately not included here.

## AI disclosure

This change was prepared with the assistance of an AI agent (Claude Code). It compared this CSV against the project's `MAINTAINERS.md`, identified the drift, located the pull requests in which each change was approved, and drafted the diff and this description. I reviewed the result and I am responsible for its accuracy.

# Checklist for maintainer updates

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [x] Optional: You've also sent a PR with affiliation updates to https://github.com/cncf/gitdm/pull/1216.
