### PR TITLE
chore: update external-secrets operator maintainer list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1411,7 +1411,7 @@ Sandbox,External Secrets Operator,Moritz Johner,Form3,moolen,https://github.com/
 ,,Lucas Severo Alves,Red Hat,knelasevero,
 ,,Gustavo Fernandes de Carvalho,Container Solutions,gusfcarvalho,
 ,,Alexander Chernov,Independent,alekc,
-,,Jean-Philippe Evrard,TLaaS,evrardjp,
+,,Jean-Philippe Evrard,TLaaS,evrardjp,
 ,,Gergely Brautigam,Kubermatic,skarlso,
 ,,Idan Adar,IBM,IdanAdar,
 Sandbox,ko,Jason Hall,Chainguard,imjasonh,https://github.com/ko-build/ko/blob/main/MAINTAINERS.md

--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1410,8 +1410,8 @@ Incubating,OpenCost,Ajay Tripathy,IBM,AjayTripathy,https://github.com/kubecost/o
 Sandbox,External Secrets Operator,Moritz Johner,Form3,moolen,https://github.com/external-secrets/external-secrets/blob/main/.github/PAUL.yaml
 ,,Lucas Severo Alves,Red Hat,knelasevero,
 ,,Gustavo Fernandes de Carvalho,Container Solutions,gusfcarvalho,
-,,Sebastian Gomez,Ubisoft,sebagomez,
-,,Shuhei Kitagawa,Mercari,shuheiktgw,
+,,Alexander Chernov,Independent,alekc,
+,,Jean-Philippe Evrard,Independent,evrardjp,
 ,,Gergely Brautigam,Kubermatic,skarlso,
 ,,Idan Adar,IBM,IdanAdar,
 Sandbox,ko,Jason Hall,Chainguard,imjasonh,https://github.com/ko-build/ko/blob/main/MAINTAINERS.md

--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1411,7 +1411,7 @@ Sandbox,External Secrets Operator,Moritz Johner,Form3,moolen,https://github.com/
 ,,Lucas Severo Alves,Red Hat,knelasevero,
 ,,Gustavo Fernandes de Carvalho,Container Solutions,gusfcarvalho,
 ,,Alexander Chernov,Independent,alekc,
-,,Jean-Philippe Evrard,Independent,evrardjp,
+,,Jean-Philippe Evrard,TLaaS,evrardjp,
 ,,Gergely Brautigam,Kubermatic,skarlso,
 ,,Idan Adar,IBM,IdanAdar,
 Sandbox,ko,Jason Hall,Chainguard,imjasonh,https://github.com/ko-build/ko/blob/main/MAINTAINERS.md


### PR DESCRIPTION
updating external-secrets operator maintainer list.

LMK if I did this wrong and should do it via another place instead 🙈

https://github.com/external-secrets/external-secrets/issues/6518
https://github.com/external-secrets/external-secrets/issues/5373

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
