### PR TITLE
chore(maintainers): add psasidhar to Athenz maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1053,6 +1053,7 @@ Sandbox,Piraeus-Datastore,Alex Zheng,DaoCloud,alexzhc,https://github.com/piraeus
 Sandbox,Athenz,Henry Avetisyan,Yahoo Inc.,havetisyan,https://github.com/AthenZ/athenz/blob/master/MAINTAINERS
 ,,Abhijeet Vaidya,Yahoo Inc.,abvaidya,
 ,,Dvir Guttman,Yahoo Inc.,dvirguttman,
+,,Sasidhar Palaka,Yahoo Inc.,psasidhar,
 Sandbox,Kube-OVN,Mengxin Liu,Alauda,oilbeater,https://github.com/alauda/kube-ovn/blob/master/MAINTAINERS
 ,,Hongzhen Ma,Alauda,hongzhen-ma,
 ,,Zujian Zhang,Alauda,zhangzujian,


### PR DESCRIPTION
# Checklist for maintainer updates

https://github.com/AthenZ/athenz/blob/master/MAINTAINERS
https://github.com/AthenZ/.project/blob/main/maintainers.yaml

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/) — https://openprofile.dev/profile/palakas
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people. *(Service Desk access already granted via an earlier maintainer-changes email from @abvaidya.)*
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).

Sasidhar Palaka (@psasidhar, Yahoo Inc.) is listed in the Athenz project's [MAINTAINERS](https://github.com/AthenZ/athenz/blob/master/MAINTAINERS) file and in the [AthenZ/.project maintainer roster](https://github.com/AthenZ/.project/blob/main/maintainers.yaml), but was missing from `project-maintainers.csv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)