### PR TITLE
Add Paolo Antinori as Apicurio Registry maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -2377,6 +2377,7 @@ Sandbox,llm-d,Abdullah Gharaibeh,Google,ahg-g,https://github.com/llm-d/llm-d/blo
 Sandbox,Apicurio Registry,Eric Wittmann,Red Hat,ericwittmann,
 ,,Jakub Senko,Individual - No Account,jsenko,
 ,,Carles Arnal,Individual - No Account,carlesarnal,
+,,Paolo Antinori,Red Hat,paoloantinori,
 Sandbox,kbind,Stefan Schimanski,NVIDIA,sttts,https://github.com/kbind-dev/kbind/blob/main/OWNERS
 ,,Moath Qasim,Kubermatic,moadqassem,
 ,,Karol Szwaj,Kubermatic,cnvergence,


### PR DESCRIPTION
Apicurio Registry has added Paolo Antinori (Red Hat) as a project maintainer. This updates `project-maintainers.csv` to match the current maintainer list in the project's [GOVERNANCE.md](https://github.com/apicurio/apicurio-registry/blob/main/GOVERNANCE.md).