### PR TITLE
Update Clusterpedia maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1381,7 +1381,8 @@ Sandbox,Aeraki Mesh,Huabing Zhao,Tencent,zhaohuabing,https://github.com/aeraki-m
 ,,Sad-polar-bear,BOSS Zhipin,Sad-polar-bear,
 ,,Xunzhuo,Tencent,Xunzhuo,
 Sandbox,Clusterpedia,Iceber Gu,DaoCloud,Iceber,https://github.com/clusterpedia-io/clusterpedia/blob/main/MAINTAINERS.md
-,,Calvin Chen,DaoCloud,calvin0327,
+,,Calvin Chen,Individual,calvin0327,
+,,Leo Shi,DaoCloud,scydas,
 ,,Yingjun Wu,China Mobile Cloud,wuyingjun-lucky,
 Incubating,OpenFeature,Alex Jones,AWS,AlexsJones,https://openfeature.dev/community/community-members
 ,,Alois Reitbauer,Dynatrace,aloisreitbauer,


### PR DESCRIPTION
## Summary

- Add Leo Shi (@scydas) as a Clusterpedia maintainer.
- Update Calvin Chen's affiliation to Individual.

## Checklist for maintainer updates

- [x] You've provided a link to documentation where the project has approved the maintainer changes: https://github.com/clusterpedia-io/clusterpedia/blob/main/MAINTAINERS.md
- [x] The maintainer(s) also created or updated their LFX Individual Dashboard profile.
- [x] You've sent an email with the list of email address(es) to cncf-maintainer-changes@cncf.io for invitations to Service Desk and mailing lists.
- [ ] Optional: You've also sent a PR with affiliation updates to cncf/gitdm.