### PR TITLE
Remove nilekhc from OPA maintainer list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -390,7 +390,6 @@ Graduated,Open Policy Agent,Tim Hinrichs,Apple,timothyhinrichs,https://github.co
 ,,Ash Narkar,Apple,ashutosh-narkar,
 ,,Charlie Egan,Apple,charlieegan3,
 ,,Max Smythe,Google,maxsmythe,
-,,Nilekh Chaudhari,Microsoft,nilekhc,
 ,,Rita Zhang,Microsoft,ritazh,
 ,,Sertaç Özercan,Microsoft,sozercan,
 ,,Jaydip Gabani,Microsoft,JaydipGabani,


### PR DESCRIPTION
Porting update from open-policy-agent/opa#8276 to
maintainers.csv as requested in open-policy-agent/.project#2

# Checklist for maintainer updates

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
