### PR TITLE
Remove Neil Smith as Podman Container Tools Maintainer

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -2128,7 +2128,7 @@ Sandbox,youki,Toru Komatsu,Preferred Networks,utam0k,https://github.com/youki-de
 Sandbox,interLink,Diego Ciangottini,INFN,dciangot,https://github.com/interTwin-eu/interLink/blob/main/MAINTAINERS.md
 ,,Daniele Spiga,INFN,spigad,
 ,,Giulio Bianchini,INFN,bianco95,
-Sandbox,Podman Container Tools,Brent Baude,Red Hat,baude,https://github.com/containers/podman/blob/main/MAINTAINERS.md
+Sandbox,Podman Container Tools,Brent Baude,Red Hat,baude,https://github.com/podman-container-tools/community/blob/main/MAINTAINERS.md
 ,,Ygal Blum,Red Hat,ygalblum,
 ,,Mohan Boddu,Red Hat,mohanboddu,
 ,,Ashley Cui,Red Hat,ashley-cui,
@@ -2139,7 +2139,6 @@ Sandbox,Podman Container Tools,Brent Baude,Red Hat,baude,https://github.com/cont
 ,,Mario Loriedo,Red Hat,l0rd,
 ,,Lokesh Mandvekar,Red Hat,lsm5,
 ,,Giuseppe Scrivano,Red Hat,giuseppe,
-,,Neil Smith,Red Hat,actionmancan,
 ,,Tom Sweeney,Red Hat,TomSweeneyRedHat,
 ,,Miloslav Trmač,Red Hat,mtrmac,
 ,,Danish Prakash,SUSE,danishprakash,


### PR DESCRIPTION
Based after https://github.com/podman-container-tools/community/pull/7

Also update the maintainer file link to the new Maintainer list in our community repo.
https://github.com/podman-container-tools/community/blob/main/MAINTAINERS.md

Maintainers for the specific projects are still listed in each repo, i.e.
https://github.com/podman-container-tools/podman/blob/main/MAINTAINERS.md

Corresponding .project repo change:
https://github.com/podman-container-tools/.project/pull/6

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [x] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
