### PR TITLE
Update kubewarden maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1475,6 +1475,9 @@ Sandbox,Kubewarden,Flavio Castelli,SUSE,flavio,https://github.com/orgs/kubewarde
 ,,Olivier Vernin,SUSE,olblak,
 ,,Alessio Greggi,SUSE,alegrey91,
 ,,Fabrizio Sestito,SUSE,fabriziosestito,
+,,Alessio Biancalana,SUSE,dottorblaster,
+,,Kyle Dong,SUSE,kyledong-suse,
+,,Shang-Wen Wang,SUSE,holyspectral,
 Graduated,Istio: Steering Committee,Ameer Abbas,Google,ameer00,https://github.com/istio/community/tree/master/steering#members
 ,,Craig Box,Solo.io,craigbox,
 ,,Rob Cernich,Red Hat,rcernich,


### PR DESCRIPTION
https://github.com/kubewarden/community/pull/102
https://github.com/kubewarden/.project/pull/8

Sync kubewarden section of project-maintainers.csv with [MAINTAINERS.md](https://github.com/kubewarden/community/blob/main/MAINTAINERS.md) This adds Alessio Biancalana, Kyle Dong, and Shang-Wen Wang to the maintainer list.

# Checklist for maintainer updates

> [!NOTE]  
> **Delete this template if you're not changing the CSV file**

- [x] You've provided a link to documentation where the project has approved the maintainer changes.
- [x] The maintainer(s) also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [ ] You've sent an email with the list of email address(es) to <cncf-maintainer-changes@cncf.io> for invitations to Service Desk and mailing lists. You can just mark this complete if you are only removing people.
- [ ] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
