### PR TITLE
Add missing maintainer apedriza to k0s

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -2082,6 +2082,7 @@ Sandbox,k0s,Jussi Nummelin,Mirantis,jnummelin,https://github.com/k0sproject/k0s/
 ,,Aleksey Makhov,Mirantis,makhov,
 ,,Kimmo Lehto,Mirantis,kke,
 ,,Ethan Mosbaugh,Replicated,emosbaugh,
+,,Alexander Pedriza,Mirantis,apedriza,
 Sandbox,kgateway,Art Berger,Solo.io,artberger,https://github.com/kgateway-dev/community/blob/main/MAINTAINERS.md
 ,,Andy Fong,Solo.io,andy-fong,
 ,,Ashley Wang,GEICO Insurance,ashleywang1,


### PR DESCRIPTION
`apedriza` (Alexander Pedriza) is listed in k0s's `maintainers.yaml` but was missing from `project-maintainers.csv`.

Found while reviewing k0sproject/.project#2.